### PR TITLE
Replace theia-ide with eclipse-cdt-cloud references

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,4 +114,4 @@ optional arguments:
 [etc]: https://www.eclipse.org/tracecompass/
 [inc]: https://projects.eclipse.org/projects/tools.tracecompass.incubator
 [rcp]: https://download.eclipse.org/tracecompass.incubator/trace-server/rcp/
-[tsp]: https://github.com/theia-ide/trace-server-protocol
+[tsp]: https://github.com/eclipse-cdt-cloud/trace-server-protocol


### PR DESCRIPTION
The repository has been moved to the Eclipse cdt-cloud project and is
now located under the eclipse-cdt-cloud GitHub organization.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>