### PR TITLE
Fix tsp_cli_client.py, tsp/entry.py

### DIFF
--- a/tsp/entry.py
+++ b/tsp/entry.py
@@ -42,7 +42,6 @@ class EntryHeader:
     '''
 
     def __init__(self, params):
-
         '''
         Displayed name
         '''

--- a/tsp_cli_client
+++ b/tsp_cli_client
@@ -41,6 +41,8 @@ from tsp.tsp_client import TspClient
 # api_token = 'your_token_goes_here'
 NS_PER_SEC = 1000000000
 
+TRACE_MISSING = "Trace UUID is missing"
+
 # pylint: disable=consider-using-f-string
 
 
@@ -132,7 +134,7 @@ def __get_tree(uuid, outputid, treetype):
         else:
             sys.exit(1)
     else:
-        print("Trace UUID is missing")
+        print(TRACE_MISSING)
         sys.exit(1)
     return None
 
@@ -328,7 +330,7 @@ if __name__ == "__main__":
                 if output_descriptor is not None:
                     print(output_descriptor)
             else:
-                print("Trace UUID is missing")
+                print(TRACE_MISSING)
                 sys.exit(1)
 
         if options.get_tree:
@@ -359,7 +361,7 @@ if __name__ == "__main__":
                 else:
                     sys.exit(1)
             else:
-                print("Trace UUID is missing")
+                print(TRACE_MISSING)
                 sys.exit(1)
 
         if options.extensions:

--- a/tsp_cli_client
+++ b/tsp_cli_client
@@ -38,7 +38,7 @@ from termcolor import colored
 from tree_model import TreeModel
 from tsp.tsp_client import TspClient
 
-#api_token = 'your_token_goes_here'
+# api_token = 'your_token_goes_here'
 NS_PER_SEC = 1000000000
 
 # pylint: disable=consider-using-f-string
@@ -79,7 +79,7 @@ def __print_outputs(descriptors):
     for descriptor in output_descriptors.descriptors:
         __print_output(descriptor)
         # TODO remove when available
-        #if o.id == "org.eclipse.tracecompass.internal.analysis.profiling.callstack.provider.CallStackDataProvider"):
+        # if o.id == "org.eclipse.tracecompass.internal.analysis.profiling.callstack.provider.CallStackDataProvider"):
         #    print('  {0}: {1} ({2})'.format("Function Duration Statistics", "Function Duration Statistics",
         #          "org.eclipse.tracecompass.internal.analysis.profiling.core.callgraph.callgraphanalysis.statistics"))
 
@@ -100,10 +100,10 @@ def __get_tree(uuid, outputid, treetype):
         if output_descriptor is None:
             print("Error fetching data provider")
             sys.exit(1)
-        
-        response = None;
 
-        if treetype == "TIME_GRAPH": 
+        response = None
+
+        if treetype == "TIME_GRAPH":
             response = tsp_client.fetch_timegraph_tree(
                 uuid, outputid)
         elif treetype == "TREE_TIME_XY":
@@ -115,8 +115,8 @@ def __get_tree(uuid, outputid, treetype):
             # fall back to timegraph-tree for older trace servers
             if response.status_code != 200:
                 response = tsp_client.fetch_timegraph_tree(
-                uuid, outputid)
-        
+                    uuid, outputid)
+
         if response is None:
             sys.exit(1)
 
@@ -332,13 +332,13 @@ if __name__ == "__main__":
                 sys.exit(1)
 
         if options.get_tree:
-            __get_tree(options.uuid, options.get_tree, "DATA_TREE");
+            __get_tree(options.uuid, options.get_tree, "DATA_TREE")
 
         if options.get_timegraph_tree:
-            __get_tree(options.uuid, options.get_timegraph_tree, "TIME_GRAPH");
+            __get_tree(options.uuid, options.get_timegraph_tree, "TIME_GRAPH")
 
         if options.get_xy_tree:
-            __get_tree(options.uuid, options.get_xy_tree, "TREE_TIME_XY");
+            __get_tree(options.uuid, options.get_xy_tree, "TREE_TIME_XY")
 
         if options.get_xy:
             if not options.items or not options.times:

--- a/tsp_cli_client
+++ b/tsp_cli_client
@@ -126,8 +126,8 @@ def __get_tree(uuid, outputid, treetype):
                 print("Tree had no model; retry?")
                 sys.exit(1)
 
-            treeModel = TreeModel(tree.entries, tree.headers)
-            treeModel.print()
+            tree_model = TreeModel(tree.entries, tree.headers)
+            tree_model.print()
             sys.exit(0)
         else:
             sys.exit(1)

--- a/tsp_cli_client
+++ b/tsp_cli_client
@@ -93,6 +93,7 @@ def __get_descriptor(uuid, output_id):
     return None
 
 
+# pylint: disable=redefined-outer-name
 def __get_tree(uuid, outputid, treetype):
     if uuid is not None:
 


### PR DESCRIPTION
Four commits with detailed commit messages:

1. Fix leftover format (minor) issues in VS Code.
2. Fix sonarlint about variable name.
3. Fix warning about duplicate string.
4. Disable pylint warning in _get_tree_.

Signed-off-by: Marco Miller <marco.miller@ericsson.com>