### PR TITLE
Implement configuration API of the TSP

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,10 +5,18 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Python: Current File",
+            "name": "Python: Test",
             "type": "python",
             "request": "launch",
             "program": ".venv/bin/pytest",
+            "console": "integratedTerminal"
+        },
+        {
+            "name": "Python: CLI",
+            "type": "python",
+            "request": "launch",
+            "program": "tsp_cli_client",
+            "args": ["--list-experiments"],
             "console": "integratedTerminal"
         }
     ]

--- a/README.md
+++ b/README.md
@@ -59,18 +59,28 @@ To use the **tsp_cli_client** script, type the following command in the root dir
 ```python
 ./tsp_cli_client -h
 
-usage: tsp_cli_client [-h] [--ip IP] [--port PORT] [--open-trace TRACE_PATH]
+usage: tsp_cli_client [-h] [--ip IP] [--port PORT] 
+                      [--open-trace TRACE_PATH]
                       [--name NAME] [--list-trace UUID] [--list-traces]
                       [--delete-trace UUID] [--open-experiment EXP_NAME]
                       [--list-experiment UUID] [--list-experiments]
                       [--delete-experiment UUID] [--list-outputs UUID]
                       [--list-output OUTPUT_ID] [--get-tree OUTPUT_ID]
+                      [--get-timegraph-tree OUTPUT_ID] 
                       [--get-xy-tree OUTPUT_ID] [--get-xy OUTPUT_ID]
                       [--items [ITEMS ...]] [--times [TIMES ...]]
                       [--uuid UUID] [--uuids [UUIDS ...]] [--do-delete-traces]
-                      [--paths [PATHS ...]] [--list-extensions]
-                      [--load-extension EXTENSION_PATH]
-                      [--delete-extension EXTENSION_NAME]
+                      [--paths [PATHS ...]]
+                      [--list-configuration-sources] 
+                      [--list-configuration-source TYPE_ID] 
+                      [--list-configurations TYPE_ID]
+                      [--list-configuration CONFIG_ID] 
+                      [--load-configuration] 
+                      [--update-configuration] 
+                      [--delete-configuration CONFIGURATION_ID]
+                      [--type-id TYPE_ID] 
+                      [--config-id CONFIG_ID] 
+                      [--params PARAMS]
 
 CLI client to send Trace Server Protocol commands to a Trace Server.
 
@@ -94,9 +104,11 @@ optional arguments:
   --list-outputs UUID   Get details on the given trace
   --list-output OUTPUT_ID
                         Get details on the given output of a trace
-  --get-tree OUTPUT_ID  Get the timegraph tree of an output
+  --get-tree OUTPUT_ID  Get the tree of an output of type DATA_TREE
+  --get-timegraph-tree OUTPUT_ID
+                        Get the tree of an output of type TIME_GRAPH
   --get-xy-tree OUTPUT_ID
-                        Get the XY tree of an output
+                        Get the tree of an output of type TREE_TIME_XY
   --get-xy OUTPUT_ID    Get the XY data of an output
   --items [ITEMS ...]   The list of XY items requested
   --times [TIMES ...]   The list of XY times requested
@@ -104,11 +116,50 @@ optional arguments:
   --uuids [UUIDS ...]   The list of UUIDs
   --do-delete-traces    Also delete traces when deleting experiment
   --paths [PATHS ...]   List of trace paths to be part of an experiment
-  --list-extensions     Get the extensions loaded
-  --load-extension EXTENSION_PATH
-                        Load an extension
-  --delete-extension EXTENSION_NAME
-                        Delete an extension
+  --list-configuration-sources
+                        Get the available configuration sources
+  --list-configuration-source TYPE_ID
+                        Get a available configuration source
+  --list-configurations TYPE_ID
+                        Get the configurations loaded for given type
+  --list-configuration CONFIG_ID
+                        Get a configuration loaded for given type and config id
+  --load-configuration  Load an configuration using paramemeters provided by --params
+  --update-configuration
+                        Update an configuration using paramemeters provided by --params
+  --delete-configuration CONFIGURATION_ID
+                        Delete a configuration
+  --type-id TYPE_ID     id of configuration source type
+  --config-id CONFIG_ID
+                        id of configuration
+  --params PARAMS       comma separated key value pairs (key1=val1,key2=val2)
+```
+
+Examples:
+```python
+  '''Open trace ''' 
+  ./tsp_cli_client --open-trace TRACE_PATH [--name NAME]
+  ./tsp_cli_client --list-traces
+  ./tsp_cli_client --list-trace UUID
+  ./tsp_cli_client --list-trace UUID
+  ./tsp_cli_client --delete-trace UUID
+  ./tsp_cli_client --open-experiment EXP_NAME --uuids UUIDS 
+  ./tsp_cli_client --open-experiment EXP_NAME --paths PATHS
+  ./tsp_cli_client --list-experiments
+  ./tsp_cli_client --list-experiment UUID
+  ./tsp_cli_client --delete-experiment UUID [--do-delete-traces]
+  ./tsp_cli_client --list-outputs UUID
+  ./tsp_cli_client --get-tree OUTPUT_ID --uuid UUID
+  ./tsp_cli_client --get-timegraph-tree OUTPUT_ID --uuid UUID
+  ./tsp_cli_client --get-xy-tree OUTPUT_ID --uuid UUID
+  ./tsp_cli_client --get-xy OUTPUT_ID --uuid UUID --items ITEMS --times TIMES
+  ./tsp_cli_client --list-configuration-sources
+  ./tsp_cli_client --list-configuration-source TYPE_ID
+  ./tsp_cli_client --list-configurations TYPE_ID
+  ./tsp_cli_client --list-configuration CONFIG_ID --type-id TYPE_ID
+  ./tsp_cli_client --load-configuration --type-id TYPE_ID --params key1:value1
+  ./tsp_cli_client --update-configuration --type-id TYPE_ID --config-id CONFIG_ID --params key1=value1,key2=value2
+  ./tsp_cli_client --delete-configuration CONFIGURATION_ID --type-id TYPE_ID
 ```
 
 [agc]: https://kislyuk.github.io/argcomplete/#activating-global-completion

--- a/tsp/configuration.py
+++ b/tsp/configuration.py
@@ -1,0 +1,81 @@
+# The MIT License (MIT)
+#
+# Copyright (C) 2020, 2023 - Ericsson
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Configuration class file."""
+
+NAME_KEY = "name"
+DESCTIPION_KEY = "description"
+ID_KEY = "id"
+SOURCE_TYPE_ID = "sourceTypeId"
+PARAMETER_KEY = "parameters"
+
+# pylint: disable=too-few-public-methods
+class Configuration:
+    '''
+    Class to handle configurations available on the remote node
+    '''
+    def __init__(self, params):
+        '''
+        Constructor
+        '''
+
+        if NAME_KEY in params:
+            self.name = params.get(NAME_KEY)
+            del params[NAME_KEY]
+        else:
+            self.name = ""
+
+        if DESCTIPION_KEY in params:
+            self.description = params.get(DESCTIPION_KEY)
+            del params[DESCTIPION_KEY]
+        else:
+            self.description = ""
+
+        if ID_KEY in params:
+            # pylint: disable=invalid-name
+            self.id = params.get(ID_KEY)
+            del params[ID_KEY]
+        else:
+            self.id = "unknown-id"
+
+        if SOURCE_TYPE_ID in params:
+            # pylint: disable=invalid-name
+            self.source_type_id = params.get(SOURCE_TYPE_ID)
+            del params[SOURCE_TYPE_ID]
+        else:
+            self.source_type_id = "unknown_source_type_id"
+
+        if PARAMETER_KEY in params:
+            # pylint: disable=invalid-name
+            self.parameters = params.get(PARAMETER_KEY)
+            del params[PARAMETER_KEY]
+        else:
+            self.parameters = {}
+
+
+    # pylint: disable=consider-using-f-string
+    def to_string(self):
+        '''
+        to_string method
+        '''
+        return 'Configuration[name={0}, description={1}, id={2}, source_type_id={3}, parameters={4}]'.format(self.name,
+          self.description, self.id, self.source_type_id, self.parameters)

--- a/tsp/configuration_parameter_descriptor.py
+++ b/tsp/configuration_parameter_descriptor.py
@@ -1,0 +1,73 @@
+# The MIT License (MIT)
+#
+# Copyright (C) 2023 - Ericsson
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Configuration parameter descriptors class file."""
+
+KEY_NAME_KEY = "keyName"
+DESCTIPION_KEY = "description"
+DATA_TYPE_KEY = "dataType"
+REQUIRED_KEY = "isRequired"
+
+# pylint: disable=too-few-public-methods
+class ConfigurationParameterDescriptor:
+    '''
+    Class to handle configuration parameter descriptor available on the remote node
+    '''
+    def __init__(self, params):
+        '''
+        Constructor
+        '''
+
+        if KEY_NAME_KEY in params:
+            self.key_name = params.get(KEY_NAME_KEY)
+            del params[KEY_NAME_KEY]
+        else:
+            self.key_name = ""
+
+        if DESCTIPION_KEY in params:
+            self.description = params.get(DESCTIPION_KEY)
+            del params[DESCTIPION_KEY]
+        else:
+            self.description = ""
+
+        if DATA_TYPE_KEY in params:
+            # pylint: disable=invalid-name
+            self.data_type = params.get(DATA_TYPE_KEY)
+            del params[DATA_TYPE_KEY]
+        else:
+            self.data_type = "STRING"
+
+        if REQUIRED_KEY in params:
+            # pylint: disable=invalid-name
+            self.is_required = params.get(REQUIRED_KEY)
+            del params[REQUIRED_KEY]
+        else:
+            self.is_required = "unknown_source_type_id"
+
+
+    # pylint: disable=consider-using-f-string
+    def to_string(self):
+        '''
+        to_string method
+        '''
+        return 'ConfigurationParameterDescriptor[key_name={0}, description={1}, data_type={2}, is_required={3}]'.format(self.key_name,
+          self.description, self.data_type, self.is_required)

--- a/tsp/configuration_parameter_descriptor_set.py
+++ b/tsp/configuration_parameter_descriptor_set.py
@@ -1,0 +1,54 @@
+# The MIT License (MIT)
+#
+# Copyright (C) 2023 - Ericsson
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""ConfigurationSet class file."""
+
+from tsp.configuration_parameter_descriptor import ConfigurationParameterDescriptor
+
+
+# pylint: disable=too-few-public-methods
+class ConfigurationParameterDescriptorSet:
+    '''
+    Class to handle configuration parameter descriptor available on the remote node
+    '''
+
+    def __init__(self, params):
+        '''
+        Constructor
+        '''
+        self.configuration_parameter_set = []
+        for obj in params:
+            self.configuration_parameter_set.append(ConfigurationParameterDescriptor(obj))
+
+
+    # pylint: disable=consider-using-f-string
+    def to_string(self):
+        '''
+        to string method
+        '''
+        sep = ''
+        my_str = ''
+        for desc in self.configuration_parameter_set:
+            my_str = my_str + '{0}{1}\n'.format(sep, desc.to_string())
+            sep = ', '
+
+        return my_str

--- a/tsp/configuration_set.py
+++ b/tsp/configuration_set.py
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 #
-# Copyright (C) 2020 - Ericsson
+# Copyright (C) 2020, 2023 - Ericsson
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,21 +20,34 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""ExtensionSet class file."""
+"""ConfigurationSet class file."""
 
-from tsp.extension import Extension
+from tsp.configuration import Configuration
 
 
 # pylint: disable=too-few-public-methods
-class ExtensionSet:
+class ConfigurationSet:
     '''
-    Class to handle extensions available on the remote node
+    Class to handle configurations available on the remote node
     '''
 
     def __init__(self, params):
         '''
         Constructor
         '''
-        self.extension_set = []
+        self.configuration_set = []
         for obj in params:
-            self.extension_set.append(Extension(obj))
+            self.configuration_set.append(Configuration(obj))
+
+
+    # pylint: disable=consider-using-f-string
+    def to_string(self):
+        '''
+        to string method
+        '''
+        my_str = ''
+        sep = ''
+        for desc in self.configuration_set:
+            my_str = my_str + '{0}{1}\n'.format(sep, desc.to_string())
+            sep = ', '
+        return my_str

--- a/tsp/configuration_source.py
+++ b/tsp/configuration_source.py
@@ -1,0 +1,78 @@
+# The MIT License (MIT)
+#
+# Copyright (C) 2023 - Ericsson
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""ConfigurationSource class file."""
+
+from tsp.configuration_parameter_descriptor_set import ConfigurationParameterDescriptorSet
+
+NAME_KEY = "name"
+DESCTIPION_KEY = "description"
+ID_KEY = "id"
+PARAM_DESC_KEY = "parameterDescriptors"
+
+
+# pylint: disable=too-few-public-methods
+class ConfigurationSource:
+    '''
+    Class to handle configurations available on the remote node
+    '''
+
+    def __init__(self, params):
+        '''
+        Constructor
+        '''
+        if NAME_KEY in params:
+            self.name = params.get(NAME_KEY)
+            del params[NAME_KEY]
+        else:
+            self.name = ""
+
+        if DESCTIPION_KEY in params:
+            self.description = params.get(DESCTIPION_KEY)
+            del params[DESCTIPION_KEY]
+        else:
+            self.description = ""
+
+        if ID_KEY in params:
+            # pylint: disable=invalid-name
+            self.id = params.get(ID_KEY)
+            del params[ID_KEY]
+        else:
+            self.id = "unknown-id"
+
+        if PARAM_DESC_KEY in params:
+            # pylint: disable=invalid-name
+            self.parameter_descriptors = ConfigurationParameterDescriptorSet(params.get(PARAM_DESC_KEY))
+
+
+    # pylint: disable=consider-using-f-string
+    def to_string(self):
+        '''
+        to_string 
+        '''
+        my_str = "no parameter descriptor"
+        if self.parameter_descriptors is not None:
+            my_str = self.parameter_descriptors.to_string()
+
+        return'Configuration Source[id={0}, name={1}, description: {2}, parameter_descriptor={3}]'.format(self.id,
+              self.name, self.description, my_str)
+

--- a/tsp/configuration_source_set.py
+++ b/tsp/configuration_source_set.py
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 #
-# Copyright (C) 2020 - Ericsson
+# Copyright (C) 2020, 2023 - Ericsson
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,17 +20,35 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""Extension class file."""
+"""ConfigurationSourceSet class file."""
+
+from tsp.configuration_source import ConfigurationSource
 
 
 # pylint: disable=too-few-public-methods
-class Extension:
+class ConfigurationSourceSet:
     '''
-    Class to handle extensions available on the remote node
+    Class to handle configuration sources available on the remote node
     '''
 
     def __init__(self, params):
         '''
         Constructor
         '''
-        self.extension = params
+        self.configuration_source_set = []
+        for obj in params:
+            self.configuration_source_set.append(ConfigurationSource(obj))
+
+    # pylint: disable=consider-using-f-string
+    def to_string(self):
+        '''
+        to string method
+        '''
+        my_str = ''
+        sep = ''
+        for desc in self.configuration_source_set:
+            my_str = my_str + '{0}{1}\n'.format(sep, desc.to_string())
+            sep = ', '
+        return my_str
+
+

--- a/tsp/tsp_client.py
+++ b/tsp/tsp_client.py
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 #
-# Copyright (C) 2020, 2022 - Ericsson
+# Copyright (C) 2020, 2023 - Ericsson
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -30,7 +30,10 @@ from tsp.trace_set import TraceSet
 from tsp.tsp_client_response import TspClientResponse
 from tsp.output_descriptor_set import OutputDescriptorSet
 from tsp.response import GenericResponse, ModelType
-from tsp.extension_set import ExtensionSet
+from tsp.configuration_source_set import ConfigurationSourceSet
+from tsp.configuration_source import ConfigurationSource
+from tsp.configuration import Configuration
+from tsp.configuration_set import ConfigurationSet
 from tsp.experiment_set import ExperimentSet
 from tsp.experiment import Experiment
 from tsp.output_descriptor import OutputDescriptor
@@ -346,46 +349,114 @@ class TspClient:
             print("failed to get xy: {0}".format(response.status_code))
             return TspClientResponse(None, response.status_code, response.text)
 
-    def fetch_extensions(self):
+    def fetch_configuration_sources(self):
         '''
         Fetch Extensions (loaded files)
         '''
-        api_url = '{0}xml'.format(self.base_url)
+        api_url = '{0}config/types/'.format(self.base_url)
 
         response = requests.get(api_url, headers=headers)
 
         if response.status_code == 200:
-            return TspClientResponse(ExtensionSet(json.loads(response.content.decode('utf-8'))),
+            return TspClientResponse(ConfigurationSourceSet(json.loads(response.content.decode('utf-8'))),
                                      response.status_code, response.text)
         else:  # pragma: no cover
-            print("failed to get extensions: {0}".format(response.status_code))
+            print("failed to get configuration sources: {0}".format(response.status_code))
             return TspClientResponse(None, response.status_code, response.text)
 
-    def post_extension(self, mypath):
+    def fetch_configuration_source(self, type_id):
+        '''
+        Fetch Extensions (loaded files)
+        '''
+        api_url = '{0}config/types/{1}'.format(self.base_url, type_id)
+
+        response = requests.get(api_url, headers=headers)
+
+        if response.status_code == 200:
+            return TspClientResponse(ConfigurationSource(json.loads(response.content.decode('utf-8'))),
+                                     response.status_code, response.text)
+        else:  # pragma: no cover
+            print("failed to get a configuration source: {0}".format(response.status_code))
+            return TspClientResponse(None, response.status_code, response.text)
+
+    def fetch_configurations(self, type_id):
+        '''
+        Fetch configurations (loaded files)
+        e.g. org.eclipse.tracecompass.tmf.core.config.xmlsourcetype
+        '''
+        api_url = '{0}config/types/{1}/configs'.format(self.base_url, type_id)
+
+        response = requests.get(api_url, headers=headers)
+
+        if response.status_code == 200:
+            return TspClientResponse(ConfigurationSet(json.loads(response.content.decode('utf-8'))),
+                                     response.status_code, response.text)
+        else:  # pragma: no cover
+            print("failed to get configurations: {0}".format(response.status_code))
+            return TspClientResponse(None, response.status_code, response.text)
+
+    def fetch_configuration(self, type_id, config_id):
+        '''
+        Fetch a configuration (loaded file)
+        e.g. org.eclipse.tracecompass.tmf.core.config.xmlsourcetype
+        '''
+        api_url = '{0}config/types/{1}/configs/{2}'.format(self.base_url, type_id, config_id)
+
+        response = requests.get(api_url, headers=headers)
+
+        if response.status_code == 200:
+            return TspClientResponse(Configuration(json.loads(response.content.decode('utf-8'))),
+                                     response.status_code, response.text)
+        else:  # pragma: no cover
+            print("failed to get configuration: {0}".format(response.status_code))
+            return TspClientResponse(None, response.status_code, response.text)
+
+
+    def post_configuration(self, type_id, params):
         '''
         Load an extension
         '''
-        api_url = '{0}xml'.format(self.base_url)
+        api_url = '{0}config/types/{1}/configs'.format(self.base_url, type_id)
 
-        payload = dict(path=mypath)
-        response = requests.post(api_url, data=payload, headers=headers_form)
+        parameters = {'parameters': params}
+
+        response = requests.post(api_url, json=parameters, headers=headers)
 
         if response.status_code == 200:
-            return TspClientResponse("Loaded", response.status_code, response.text)
+            return TspClientResponse(Configuration(json.loads(response.content.decode('utf-8'))),
+                                     response.status_code, response.text)
         else:  # pragma: no cover
             print("post extension failed: {0}".format(response.status_code))
             return TspClientResponse(None, response.status_code, response.text)
 
-    def delete_extension(self, name):
+    def put_configuration(self, type_id, config_id, params):
+        '''
+        Load an extension
+        '''
+        api_url = '{0}config/types/{1}/configs/{2}'.format(self.base_url, type_id, config_id)
+
+        parameters = {'parameters': params}
+
+        response = requests.put(api_url, json=parameters, headers=headers)
+
+        if response.status_code == 200:
+            return TspClientResponse(Configuration(json.loads(response.content.decode('utf-8'))), 
+                                     response.status_code, response.text)
+        else:  # pragma: no cover
+            print("put extension failed: {0}".format(response.status_code))
+            return TspClientResponse(None, response.status_code, response.text)
+
+    def delete_configuration(self, type_id, config_id):
         '''
         Delete an extension
         '''
-        api_url = '{0}xml/{1}'.format(self.base_url, name)
+        api_url = '{0}config/types/{1}/configs/{2}'.format(self.base_url, type_id, config_id)
 
         response = requests.delete(api_url, headers=headers_form)
 
         if response.status_code == 200:
-            return TspClientResponse("Deleted", response.status_code, response.text)
+            return TspClientResponse(Configuration(json.loads(response.content.decode('utf-8'))),
+                                     response.status_code, response.text)
         else:  # pragma: no cover
             print("post extension failed: {0}".format(response.status_code))
             return TspClientResponse(None, response.status_code, response.text)

--- a/tsp_cli_client
+++ b/tsp_cli_client
@@ -4,7 +4,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (C) 2020, 2022 - Ericsson
+# Copyright (C) 2020, 2023 - Ericsson
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -31,6 +31,7 @@ import sys
 
 from os.path import os
 
+import re
 import argcomplete
 import requests
 
@@ -60,6 +61,8 @@ def __print_experiment(elem):
     print('------')
     for elem_trace in elem.traces.traces:
         __print_trace(elem_trace)
+    
+    print('')
 
 
 def __print_trace(elem):
@@ -139,6 +142,18 @@ def __get_tree(uuid, outputid, treetype):
         sys.exit(1)
     return None
 
+def __parse_params (parameters_string):
+    pairs = re.split(',', parameters_string)
+    _params = {}
+    for pair in pairs:
+        pair_list = re.split('=', pair)
+        if len(pair_list) < 2:
+            return None
+
+        _params[pair_list[0]] = pair_list[1]
+
+    return _params
+
 
 DESCRIPTION = """CLI client to send Trace Server Protocol commands to a Trace Server."""
 
@@ -190,12 +205,23 @@ if __name__ == "__main__":
                         action='store_true', help="Also delete traces when deleting experiment")
     parser.add_argument("--paths", dest="paths",
                         help="List of trace paths to be part of an experiment", nargs="*")
-    parser.add_argument("--list-extensions", dest="extensions",
-                        action='store_true', help="Get the extensions loaded")
-    parser.add_argument("--load-extension", dest="load_extension",
-                        help="Load an extension", metavar="EXTENSION_PATH")
-    parser.add_argument("--delete-extension", dest="delete_extension",
-                        help="Delete an extension", metavar="EXTENSION_NAME")
+    parser.add_argument("--list-configuration-sources", dest="list_configuration_sources",
+                        action='store_true', help="Get the available configuration sources")
+    parser.add_argument("--list-configuration-source", dest="list_configuration_source",
+                        help="Get a available configuration source", metavar="TYPE_ID")
+    parser.add_argument("--list-configurations", dest="list_configurations",
+                        help="Get the configurations loaded for given type", metavar="TYPE_ID")
+    parser.add_argument("--list-configuration", dest="list_configuration",
+                        help="Get a configuration loaded for given type and config id", metavar="CONFIG_ID")
+    parser.add_argument("--load-configuration", dest="load_configuration",
+                        action='store_true', help="Load an configuration using paramemeters provided by --params")
+    parser.add_argument("--update-configuration", dest="update_configuration",
+                        action='store_true', help="Update an configuration using paramemeters provided by --params")
+    parser.add_argument("--delete-configuration", dest="delete_configuration",
+                        help="Delete a configuration", metavar="CONFIGURATION_ID")
+    parser.add_argument("--type-id", dest="type_id", help="id of configuration source type")
+    parser.add_argument("--config-id", dest="config_id", help="id of configuration")
+    parser.add_argument("--params", dest="params", help="comma separated key value pairs (key1=val1,key2=val2)")
 
     argcomplete.autocomplete(parser)
     options = parser.parse_args()
@@ -365,31 +391,111 @@ if __name__ == "__main__":
                 print(TRACE_MISSING)
                 sys.exit(1)
 
-        if options.extensions:
-            response = tsp_client.fetch_extensions()
+        if options.list_configuration_sources:
+            response = tsp_client.fetch_configuration_sources()
             if response.status_code == 200:
-                extension_set = response.model
-                if not extension_set:
-                    print('No extensions loaded')
-                for e in extension_set.extension_set:
-                    print('  {0}'.format(e.extension))
+                configuration_source_set = response.model
+                if not configuration_source_set or len(configuration_source_set.configuration_source_set) == 0:
+                    print('No configuration sources available')
+                else:
+                    print('  {0}'.format(configuration_source_set.to_string()))
                 sys.exit(0)
             else:
                 sys.exit(1)
 
-        if options.load_extension:
-            response = tsp_client.post_extension(options.load_extension)
+        if options.list_configuration_source:
+            response = tsp_client.fetch_configuration_source(options.list_configuration_source)
             if response.status_code == 200:
+                print('  {0}'.format(response.model.to_string()))
                 sys.exit(0)
             else:
                 sys.exit(1)
 
-        if options.delete_extension:
-            response = tsp_client.delete_extension(options.delete_extension)
+        if options.list_configurations:
+            response = tsp_client.fetch_configurations(options.list_configurations)
             if response.status_code == 200:
+                configuration_set = response.model
+                if not configuration_set or len(configuration_set.configuration_set) == 0:
+                    print('No configurations loaded')
+                else:
+                    print('  {0}'.format(configuration_set.to_string()))
                 sys.exit(0)
             else:
                 sys.exit(1)
+
+
+        if options.list_configuration:
+            if options.type_id is not None:
+                response = tsp_client.fetch_configuration(options.type_id, options.list_configuration)
+                if response.status_code == 200:
+                    print('  {0}'.format(response.model.to_string()))
+                    sys.exit(0)
+                else:
+                    sys.exit(1)
+            else:
+                print("No type id of configuration provided")
+                sys.exit(1)
+
+
+
+        if options.load_configuration:
+            if options.type_id is not None:
+                if options.params is not None:
+                    params = __parse_params(options.params)
+                    if (params is not None):
+                        response = tsp_client.post_configuration(options.type_id, params)
+                        if response.status_code == 200:
+                            print('  {0}'.format(response.model.to_string()))
+                            sys.exit(0)
+                        else:
+                            sys.exit(1)
+                    else:
+                        print("Invalid params provided")
+                        sys.exit(1)
+                else:
+                    print("No params provided")
+                    sys.exit(1)
+            else:
+                print("No type id of configuration provided")
+                sys.exit(1)
+
+        if options.update_configuration:
+            if options.type_id is not None:
+                if (options.config_id is not None):
+                    if options.params is not None:
+                        params = __parse_params(options.params);
+                        if (params is not None):
+                            response = tsp_client.put_configuration(options.type_id, options.config_id, params)
+                            if response.status_code == 200:
+                                print('  {0}'.format(response.model.to_string()))
+                                sys.exit(0)
+                            else:
+                                sys.exit(1)
+                        else:
+                            print("Invalid params provided")
+                            sys.exit(1)
+                    else:
+                        print("No params provided")
+                        sys.exit(1)
+                else:
+                    print("No config id if configuration provided")
+                    sys.exit(1)
+            else:
+                print("No type id of configuration provided")
+                sys.exit(1)
+
+        if options.delete_configuration:
+            if options.type_id is not None:
+                response = tsp_client.delete_configuration(options.type_id, options.delete_configuration)
+                if response.status_code == 200:
+                    print('  {0}'.format(response.model.to_string()))
+                    sys.exit(0)
+                else:
+                    sys.exit(1)
+            else:
+                print("No source typeId provided to delete this configuration")
+
+
     except requests.exceptions.ConnectionError as e:
         print('Unexpected error: {0}'.format(e))
         sys.exit(1)


### PR DESCRIPTION
It replaces the list/load/delete extension CLI that used the undocumented XML endpoint of Trace Compass server. It adds the following commands and corresponding TSP API calls:

- --list-configuration-sources: list all the configuration source types
- --list-configuration-sourceL list a single configuration source type
- --list-configurations: list loaded configurations for a source type
- --list-configuration: list a single configuration for a source type
- --load-configuration: load a configuration for a source type
- --update-configuration: update a configuration for a source type
- --delete-configuration: delete a configuration for a source type

Update README.md as well for these new commands.

See corresponding TSP updates for that:
https://github.com/eclipse-cdt-cloud/trace-server-protocol/pull/93

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>