### PR TITLE
Use __str__ instead of to_string()

### DIFF
--- a/tree_model.py
+++ b/tree_model.py
@@ -121,17 +121,15 @@ class TreeItem:
                 for _ in range((int)(depth / self._indent) - 1):
                     print("| ", end="")
                 # TODO print TimeGraphEntry specific fields below; re-enable pylint's:
-                # pylint: disable=consider-using-f-string
-                print("{0}{1} ({1}, {2}) {3}".format(
-                    prefix, self._entry.labels[0], self._entry.id, self._entry.parent_id))
+                print(f'{prefix}{labels[0]} ({labels[0]}, {self._entry.id}) {self._entry.parent_id}')
             else:
                 label_str = ""
                 if depth > 0:
-                    label_str = label_str + "  "
+                    label_str += "  "
                 for _ in range((int)(depth / self._indent) - 1):
-                    label_str = label_str + "| "
+                    label_str += "| "
                 i = 0
-                label_str = label_str + prefix
+                label_str += prefix
                 for label in labels:
                     if i == 0:
                         row.append(label_str + label)

--- a/tsp/configuration.py
+++ b/tsp/configuration.py
@@ -72,10 +72,8 @@ class Configuration:
             self.parameters = {}
 
 
-    # pylint: disable=consider-using-f-string
-    def to_string(self):
+    def __str__(self):
         '''
         to_string method
         '''
-        return 'Configuration[name={0}, description={1}, id={2}, source_type_id={3}, parameters={4}]'.format(self.name,
-          self.description, self.id, self.source_type_id, self.parameters)
+        return f'Configuration[name={self.name}, description={self.description}, id={self.id}, source_type_id={self.source_type_id}, parameters={self.parameters}]'

--- a/tsp/configuration_parameter_descriptor.py
+++ b/tsp/configuration_parameter_descriptor.py
@@ -64,10 +64,8 @@ class ConfigurationParameterDescriptor:
             self.is_required = "unknown_source_type_id"
 
 
-    # pylint: disable=consider-using-f-string
-    def to_string(self):
+    def __str__(self):
         '''
         to_string method
         '''
-        return 'ConfigurationParameterDescriptor[key_name={0}, description={1}, data_type={2}, is_required={3}]'.format(self.key_name,
-          self.description, self.data_type, self.is_required)
+        return f'ConfigurationParameterDescriptor[key_name={self.key_name}, description={self.description}, data_type={self.data_type}, is_required={self.is_required}]'

--- a/tsp/configuration_parameter_descriptor_set.py
+++ b/tsp/configuration_parameter_descriptor_set.py
@@ -40,15 +40,14 @@ class ConfigurationParameterDescriptorSet:
             self.configuration_parameter_set.append(ConfigurationParameterDescriptor(obj))
 
 
-    # pylint: disable=consider-using-f-string
-    def to_string(self):
+    def __str__(self):
         '''
         to string method
         '''
         sep = ''
         my_str = ''
         for desc in self.configuration_parameter_set:
-            my_str = my_str + '{0}{1}\n'.format(sep, desc.to_string())
+            my_str = my_str + f'{sep}{desc}\n'
             sep = ', '
 
         return my_str

--- a/tsp/configuration_set.py
+++ b/tsp/configuration_set.py
@@ -40,14 +40,13 @@ class ConfigurationSet:
             self.configuration_set.append(Configuration(obj))
 
 
-    # pylint: disable=consider-using-f-string
-    def to_string(self):
+    def __str__(self):
         '''
         to string method
         '''
         my_str = ''
         sep = ''
         for desc in self.configuration_set:
-            my_str = my_str + '{0}{1}\n'.format(sep, desc.to_string())
+            my_str += f'{sep}{desc}\n'
             sep = ', '
         return my_str

--- a/tsp/configuration_source.py
+++ b/tsp/configuration_source.py
@@ -64,15 +64,13 @@ class ConfigurationSource:
             self.parameter_descriptors = ConfigurationParameterDescriptorSet(params.get(PARAM_DESC_KEY))
 
 
-    # pylint: disable=consider-using-f-string
-    def to_string(self):
+    def __str__(self):
         '''
         to_string 
         '''
         my_str = "no parameter descriptor"
         if self.parameter_descriptors is not None:
-            my_str = self.parameter_descriptors.to_string()
+            my_str = str(self.parameter_descriptors)
 
-        return'Configuration Source[id={0}, name={1}, description: {2}, parameter_descriptor={3}]'.format(self.id,
-              self.name, self.description, my_str)
+        return f'Configuration Source[id={self.id}, name={self.name}, description: {self.description}, parameter_descriptor={my_str}]'
 

--- a/tsp/configuration_source_set.py
+++ b/tsp/configuration_source_set.py
@@ -39,15 +39,14 @@ class ConfigurationSourceSet:
         for obj in params:
             self.configuration_source_set.append(ConfigurationSource(obj))
 
-    # pylint: disable=consider-using-f-string
-    def to_string(self):
+    def __str__(self):
         '''
         to string method
         '''
         my_str = ''
         sep = ''
         for desc in self.configuration_source_set:
-            my_str = my_str + '{0}{1}\n'.format(sep, desc.to_string())
+            my_str = my_str + f'{sep}{desc}\n'
             sep = ', '
         return my_str
 

--- a/tsp_cli_client
+++ b/tsp_cli_client
@@ -398,7 +398,7 @@ if __name__ == "__main__":
                 if not configuration_source_set or len(configuration_source_set.configuration_source_set) == 0:
                     print('No configuration sources available')
                 else:
-                    print('  {0}'.format(configuration_source_set.to_string()))
+                    print(f'  {configuration_source_set}')
                 sys.exit(0)
             else:
                 sys.exit(1)
@@ -406,7 +406,7 @@ if __name__ == "__main__":
         if options.list_configuration_source:
             response = tsp_client.fetch_configuration_source(options.list_configuration_source)
             if response.status_code == 200:
-                print('  {0}'.format(response.model.to_string()))
+                print(f'  {response.model}')
                 sys.exit(0)
             else:
                 sys.exit(1)
@@ -418,7 +418,7 @@ if __name__ == "__main__":
                 if not configuration_set or len(configuration_set.configuration_set) == 0:
                     print('No configurations loaded')
                 else:
-                    print('  {0}'.format(configuration_set.to_string()))
+                    print(f'  {configuration_set}')
                 sys.exit(0)
             else:
                 sys.exit(1)
@@ -428,7 +428,7 @@ if __name__ == "__main__":
             if options.type_id is not None:
                 response = tsp_client.fetch_configuration(options.type_id, options.list_configuration)
                 if response.status_code == 200:
-                    print('  {0}'.format(response.model.to_string()))
+                    print(f'  {response.model}
                     sys.exit(0)
                 else:
                     sys.exit(1)


### PR DESCRIPTION
Works with str(object) and print(object). It is the more "pythonic" way.

Replace all .format strings with fstrings and remove linter directives.