### PR TITLE
Add an endpoint for closing an experiment

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ optional arguments:
   --list-experiment UUID
                         Get details on the given experiment
   --list-experiments    List all open experiments on the server
+  --close-experiment UUID
+                        Close an experiment on the server
   --delete-experiment UUID
                         Delete an experiment on the server
   --list-outputs UUID   Get details on the given trace
@@ -147,6 +149,7 @@ Examples:
   ./tsp_cli_client --open-experiment EXP_NAME --paths PATHS
   ./tsp_cli_client --list-experiments
   ./tsp_cli_client --list-experiment UUID
+  ./tsp_cli_client --close-experiment UUID
   ./tsp_cli_client --delete-experiment UUID [--do-delete-traces]
   ./tsp_cli_client --list-outputs UUID
   ./tsp_cli_client --get-tree OUTPUT_ID --uuid UUID

--- a/test_tsp.py
+++ b/test_tsp.py
@@ -188,8 +188,14 @@ class TestTspClient:
             os.path.basename(kernel), traces)
         assert response.status_code == 200
 
+        exp_uuid = response.model.UUID
+
         response = self.tsp_client.fetch_experiments()
         assert len(response.model.experiments) == 1
+
+        response = self.tsp_client.close_experiment(exp_uuid)
+        assert response.model.indexin_status == "CLOSED"
+
         self._delete_experiments()
         self._delete_traces()
 

--- a/tsp/tsp_client.py
+++ b/tsp/tsp_client.py
@@ -172,6 +172,25 @@ class TspClient:
             print("get trace failed: {0}".format(response.status_code))
             return TspClientResponse(None, response.status_code, response.text)
 
+    def close_experiment(self, uuid):
+        '''
+        Close a specific experiment
+        :param uuid: Experiment UUID to fetch
+        :return: :class:`TspClientResponse <Experiment>` object
+        :rtype: TspClientResponse
+        '''
+        api_url = '{0}experiments/{1}:close'.format(self.base_url, uuid)
+        parameters = {'parameters': {}}
+
+        response = requests.put(api_url, json=parameters, headers=headers)
+
+        if response.status_code == 200:
+            return TspClientResponse(Experiment(json.loads(response.content.decode('utf-8'))),
+                                     response.status_code, response.text)
+        else:  # pragma: no cover
+            print("delete experiment failed: {0}".format(response.status_code))
+            return TspClientResponse(None, response.status_code, response.text)
+
     def delete_experiment(self, uuid):
         '''
         Delete a specific experiment

--- a/tsp_cli_client
+++ b/tsp_cli_client
@@ -180,6 +180,8 @@ if __name__ == "__main__":
                         help="Get details on the given experiment", metavar="UUID")
     parser.add_argument("--list-experiments", dest="list_experiments",
                         action='store_true',  help="List all open experiments on the server")
+    parser.add_argument("--close-experiment", dest="close_experiment",
+                        help="Close an experiment on the server", metavar="UUID")
     parser.add_argument("--delete-experiment", dest="delete_experiment",
                         help="Delete an experiment on the server", metavar="UUID")
     parser.add_argument("--list-outputs", dest="list_outputs",
@@ -321,6 +323,15 @@ if __name__ == "__main__":
                     __print_experiment(exp)
                 sys.exit(0)
             else:
+                sys.exit(1)
+
+        if options.close_experiment:
+            response = tsp_client.close_experiment(options.close_experiment)
+            if response.status_code == 200:
+                print("Successfully closed experiment")
+                sys.exit(0)
+            else:
+                print("Failed closing experiment with error " + response.status_code)
                 sys.exit(1)
 
         if options.delete_experiment:


### PR DESCRIPTION
With this it's possible to close an experiment on the server. Upon reception of the command the server can dispose allocated resources hence the client doesn't need them anymore.

This change follows the TSP update provided by:
https://github.com/eclipse-cdt-cloud/trace-server-protocol/pull/95

Also add CLI option and unit test for this.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>