### PR TITLE
Get-XY with time range option

### DIFF
--- a/tsp/tsp_client.py
+++ b/tsp/tsp_client.py
@@ -57,6 +57,11 @@ class TspClient:
     PARAMETERS_KEY = 'parameters'
     REQUESTED_TIME_KEY = 'requested_times'
     REQUESTED_ITEM_KEY = 'requested_items'
+    
+    REQUESTED_TIME_RANGE_KEY = 'requested_timerange'
+    REQUESTED_TIME_RANGE_START_KEY = 'start'
+    REQUESTED_TIME_RANGE_END_KEY = 'end'
+    REQUESTED_TIME_RANGE_NUM_TIMES_KEY = 'nbTimes'
 
     def __init__(self, base_url):
         '''

--- a/tsp/xy_model.py
+++ b/tsp/xy_model.py
@@ -58,7 +58,7 @@ class XYModel:
                 self.series.append(XYSeries(series))
             del params[SERIES_KEY]
 
-    def print(self):  # pragma: no cover
+    def print(self, array_print=False):  # pragma: no cover
         '''
         XY model rendering below
         '''
@@ -70,7 +70,7 @@ class XYModel:
         print(f'XY has common X axis: {common_x_axis}')
 
         for series in self.series:
-            series.print()
+            series.print(array_print)
 
 
 class XYSeries:
@@ -122,7 +122,7 @@ class XYSeries:
                 self.tags.append(tag)
             del params[TAGS_KEY]
 
-    def print(self):  # pragma: no cover
+    def print(self, array_print=False):  # pragma: no cover
         '''
         XY series rendering below
         '''
@@ -132,13 +132,18 @@ class XYSeries:
         if hasattr(self, 'x_axis'):
             print(f' Series X-axis:\n{self.x_axis.print()}')
             print(f' Series Y-axis:\n{self.y_axis.print()}')
-        for value in self.x_values:
-            print(f' Series X-value: {value}')
-        for value in self.y_values:
-            print(f' Series Y-value: {value}')
-        for tag in self.tags:
-            print(f' Series tag: {tag}')
-
+            
+        if not array_print:    
+            for value in self.x_values:
+                print(f' Series X-value: {value}')
+            for value in self.y_values:
+                print(f' Series Y-value: {value}')
+            for tag in self.tags:
+                print(f' Series tag: {tag}')
+        else:
+            print(f' Series X-values: {self.x_values}')
+            print(f' Series Y-values: {self.y_values}')
+            print(f' Series tags: {self.tags}')
 
 class XYAxis:
     '''

--- a/tsp_cli_client
+++ b/tsp_cli_client
@@ -400,7 +400,7 @@ if __name__ == "__main__":
                     options.uuid, options.get_xy, params)
                 if response.status_code == 200:
                     xyModel = response.model.model
-                    xyModel.print()
+                    xyModel.print(array_print=True if options.time_range else False)
                     sys.exit(0)
                 else:
                     sys.exit(1)

--- a/tsp_cli_client
+++ b/tsp_cli_client
@@ -198,6 +198,8 @@ if __name__ == "__main__":
                         help="The list of XY items requested", nargs="*")
     parser.add_argument("--times", dest="times",
                         help="The list of XY times requested", nargs="*")
+    parser.add_argument("--time-range", dest="time_range",
+                        help="The time range requested", nargs=3)
     parser.add_argument("--uuid", dest="uuid", help="The UUID of a trace")
     parser.add_argument("--uuids", dest="uuids",
                         help="The list of UUIDs", nargs="*")
@@ -370,13 +372,28 @@ if __name__ == "__main__":
             __get_tree(options.uuid, options.get_xy_tree, "TREE_TIME_XY")
 
         if options.get_xy:
-            if not options.items or not options.times:
-                print("Provide requested --items and --times for the XY data")
+            if not options.items:
+                print("Provide requested --items for the XY data")
+                sys.exit(1)
+
+            if not options.times and not options.time_range:
+                print("Provide either requested --times or --time-range for the XY data")
                 sys.exit(1)
 
             if options.uuid is not None:
-                parameters = {TspClient.REQUESTED_TIME_KEY: list(map(int, options.times)),
-                              TspClient.REQUESTED_ITEM_KEY: list(map(int, options.items))}
+                parameters = {TspClient.REQUESTED_ITEM_KEY: list(map(int, options.items))}
+                if options.times:
+                    parameters[TspClient.REQUESTED_TIME_KEY] = list(map(int, options.times))
+                elif options.time_range:
+                    start_time = int(options.time_range[0])
+                    end_time = int(options.time_range[1])
+                    nb_times = int(options.time_range[2])
+                    parameters[TspClient.REQUESTED_TIME_RANGE_KEY] = {
+                        TspClient.REQUESTED_TIME_RANGE_START_KEY: start_time,
+                        TspClient.REQUESTED_TIME_RANGE_END_KEY: end_time,
+                        TspClient.REQUESTED_TIME_RANGE_NUM_TIMES_KEY: nb_times
+                    }
+                
                 params = {TspClient.PARAMETERS_KEY: parameters}
 
                 response = tsp_client.fetch_xy(


### PR DESCRIPTION
## Changes in commit 2c0fcb068af27c9334b3220e19b46a0b653f5ada
Added the implementation of the Get-XY with the time rage to the Python client. As documented in the [TSP Server Documentation](https://eclipse-cdt-cloud.github.io/trace-server-protocol/#tag/XY/operation/getXY), the time rage option was added to the get-xy function. It is now possible to use the following structure to fetch the xy data based on the time range.
```python
./tsp_cli_client --get-xy OUTPUT_ID --uuid UUID --items ITEMS --time-range START END NB_TIMES
```
where:
- START is the beginning timestamp of the time range
- END is the end timestamp of the time range
- NB_TIMES is the number of samples that should be fetched

## Changes in commit 4ebd082c85a63bf2fabe759d19c51883557ac8cf
As it was previously implemented, when requesting a time range (or multiple times) for the get-xy module, the output shows the results line-by-line for each data point. In other words, when requesting 10 data points, the output would be:
```console
XY has common X axis: False | True
    Series name: NAME
    Series id: ID
    Series X-value: X1
    Series X-value: X2
    Series X-value: X3
    Series X-value: X4
    Series X-value: X5
    Series X-value: X6
    Series X-value: X7
    Series X-value: X8
    Series X-value: X9
    Series X-value: X10
    Series Y-value: Y1
    Series Y-value: Y2
    Series Y-value: Y3
    Series Y-value: Y4
    Series Y-value: Y5
    Series Y-value: Y6
    Series Y-value: Y7
    Series Y-value: Y8
    Series Y-value: Y9
    Series Y-value: Y10
```

Now, in this commit, the `array_print` parameters has been added to the `XYModel.print` method in order to print the results in an array format instead of line-by-line. The results then would be:
```console
XY has common X axis: False | True
    Series name: NAME
    Series id: ID
    Series X-values: [X1,X2,X3...,X10]
    Series Y-values: [Y1, Y2, Y3, ..., Y10]
```