### PR TITLE
Get virtual table lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ usage: tsp_cli_client [-h] [--ip IP] [--port PORT]
                       [--list-output OUTPUT_ID] [--get-tree OUTPUT_ID]
                       [--get-timegraph-tree OUTPUT_ID] 
                       [--get-xy-tree OUTPUT_ID] [--get-xy OUTPUT_ID]
-                      [--items [ITEMS ...]] [--times [TIMES ...]]
+                      [--items [ITEMS ...]] [--time-range START END NUM_TIMES]
                       [--uuid UUID] [--uuids [UUIDS ...]] [--do-delete-traces]
                       [--paths [PATHS ...]]
                       [--list-configuration-sources] 
@@ -111,7 +111,8 @@ optional arguments:
                         Get the tree of an output of type TREE_TIME_XY
   --get-xy OUTPUT_ID    Get the XY data of an output
   --items [ITEMS ...]   The list of XY items requested
-  --times [TIMES ...]   The list of XY times requested
+  --time-range START END NUM_TIMES
+                        The time range requested
   --uuid UUID           The UUID of a trace
   --uuids [UUIDS ...]   The list of UUIDs
   --do-delete-traces    Also delete traces when deleting experiment
@@ -152,7 +153,7 @@ Examples:
   ./tsp_cli_client --get-tree OUTPUT_ID --uuid UUID
   ./tsp_cli_client --get-timegraph-tree OUTPUT_ID --uuid UUID
   ./tsp_cli_client --get-xy-tree OUTPUT_ID --uuid UUID
-  ./tsp_cli_client --get-xy OUTPUT_ID --uuid UUID --items ITEMS --times TIMES
+  ./tsp_cli_client --get-xy OUTPUT_ID --uuid UUID --items ITEMS --time-range START END NUM_TIMES
   ./tsp_cli_client --list-configuration-sources
   ./tsp_cli_client --list-configuration-source TYPE_ID
   ./tsp_cli_client --list-configurations TYPE_ID

--- a/tsp/model_type.py
+++ b/tsp/model_type.py
@@ -35,3 +35,4 @@ class ModelType(Enum):
     STATES = "states"
     XY = "xy"
     DATA_TREE = "data_tree"
+    VIRTUAL_TABLE = "virtual_table"

--- a/tsp/response.py
+++ b/tsp/response.py
@@ -28,6 +28,7 @@ from tsp.model_type import ModelType
 from tsp.output_descriptor import OutputDescriptor
 from tsp.entry_model import EntryModel
 from tsp.xy_model import XYModel
+from tsp.virtual_table_model import VirtualTableModel
 
 MODEL_KEY = "model"
 OUTPUT_DESCRIPTOR_KEY = "output"
@@ -87,6 +88,8 @@ class GenericResponse:
                 self.model = XYModel(params.get(MODEL_KEY))
             elif self.model_type == ModelType.DATA_TREE:
                 self.model = EntryModel(params.get(MODEL_KEY), self.model_type)
+            elif self.model_type == ModelType.VIRTUAL_TABLE: 
+                self.model = VirtualTableModel(params.get(MODEL_KEY))
 
         # Output descriptor
         if OUTPUT_DESCRIPTOR_KEY in params:

--- a/tsp/tsp_client.py
+++ b/tsp/tsp_client.py
@@ -57,6 +57,11 @@ class TspClient:
     PARAMETERS_KEY = 'parameters'
     REQUESTED_TIME_KEY = 'requested_times'
     REQUESTED_ITEM_KEY = 'requested_items'
+    
+    REQUESTED_TIME_RANGE_KEY = 'requested_timerange'
+    REQUESTED_TIME_RANGE_START_KEY = 'start'
+    REQUESTED_TIME_RANGE_END_KEY = 'end'
+    REQUESTED_TIME_RANGE_NUM_TIMES_KEY = 'nbTimes'
 
     def __init__(self, base_url):
         '''

--- a/tsp/tsp_client.py
+++ b/tsp/tsp_client.py
@@ -63,6 +63,12 @@ class TspClient:
     REQUESTED_TIME_RANGE_END_KEY = 'end'
     REQUESTED_TIME_RANGE_NUM_TIMES_KEY = 'nbTimes'
 
+    REQUESTED_TABLE_LINE_INDEX_KEY = 'requested_table_index'
+    REQUESTED_TABLE_LINE_COUNT_KEY = 'requested_table_count'
+    REQUESTED_TABLE_LINE_COLUMN_IDS_KEY = 'requested_table_column_ids'
+    REQUESTED_TABLE_LINE_SEACH_DIRECTION_KEY = 'table_search_direction'
+    REQUESTED_TABLE_LINE_SEARCH_EXPRESSION_KEY = 'table_search_expressions'
+
     def __init__(self, base_url):
         '''
         Constructor
@@ -275,6 +281,34 @@ class TspClient:
         if response.status_code == 200:
             return TspClientResponse(GenericResponse(json.loads(response.content.decode('utf-8')),
                                                      ModelType.DATA_TREE),
+                                     response.status_code, response.text)
+        else:  # pragma: no cover
+            print(GET_TREE_FAILED.format(response.status_code))
+            return TspClientResponse(None, response.status_code, response.text)
+        
+    def fetch_virtual_table_lines(self, exp_uuid, output_id, parameters=None):
+        '''
+        Fetch Virtual Table lines, Model extends VirtualTableModel
+        :param exp_uuid: Experiment UUID
+        :param output_id: Output ID
+        :param parameters: Query object
+        :returns: :class:  `TspClientResponse <GenericResponse>` object Virtual Table lines response
+        :rtype: TspClientResponse
+        '''
+        api_url = '{0}experiments/{1}/outputs/table/{2}/lines'.format(
+            self.base_url, exp_uuid, output_id)
+
+        params = parameters
+        if parameters is None:
+            params = {
+                TspClient.PARAMETERS_KEY: {}
+            }
+
+        response = requests.post(api_url, json=params, headers=headers)
+
+        if response.status_code == 200:
+            return TspClientResponse(GenericResponse(json.loads(response.content.decode('utf-8')),
+                                                     ModelType.VIRTUAL_TABLE),
                                      response.status_code, response.text)
         else:  # pragma: no cover
             print(GET_TREE_FAILED.format(response.status_code))

--- a/tsp/virtual_table_model.py
+++ b/tsp/virtual_table_model.py
@@ -1,0 +1,124 @@
+# The MIT License (MIT)
+#
+# Copyright (C) 2024 - Ericsson
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""VirtualTableModel class file."""
+
+SIZE_KEY = "size"
+LOW_INDEX_KEY = "lowIndex"
+COLUMN_IDS_KEY = "columnIds"
+LINES_KEY = "lines"
+
+TABLE_LINE_INDEX_KEY = "index"
+TABLE_LINE_CELLS_KEY = "cells"
+TABLE_LINE_CELL_CONTENT_KEY = "content"
+
+
+# pylint: disable=too-few-public-methods
+class VirtualTableModel:
+    '''
+    Virtual table model that will be returned by the server
+    '''
+
+    def __init__(self, params):
+        # Size of the virtual table
+        self.size = 0
+        if SIZE_KEY in params:
+            if params.get(SIZE_KEY) is not None and type(params.get(SIZE_KEY)) is int:
+                self.size = int(params.get(SIZE_KEY))
+            del params[SIZE_KEY]
+
+        # Index of the first line in the virtual table
+        self.low_index = 0
+        if LOW_INDEX_KEY in params:
+            if params.get(LOW_INDEX_KEY) is not None and type(params.get(LOW_INDEX_KEY)) is int:
+                self.low_index = int(params.get(LOW_INDEX_KEY))
+            del params[LOW_INDEX_KEY]
+
+        # Array of column IDs in the virtual table
+        self.column_ids = []
+        if COLUMN_IDS_KEY in params:
+            if params.get(COLUMN_IDS_KEY) is not None:
+                for column_id in params.get(COLUMN_IDS_KEY):
+                    self.column_ids.append(column_id)
+            del params[COLUMN_IDS_KEY]
+
+        # Array of lines in the virtual table
+        self.lines = []
+        if LINES_KEY in params:
+            for line in params.get(LINES_KEY):
+                self.lines.append(VirtualTableLine(line))
+            del params[LINES_KEY]
+
+    def print(self):
+        print("VirtualTableModel:")
+        print(f"  size: {self.size}")
+        print(f"  low_index: {self.low_index}")
+        print(f"  column_ids: {self.column_ids}")
+
+        print("  lines:")
+        for i, line in enumerate(self.lines):
+            line.print()
+
+class VirtualTableLine:
+    '''
+    Virtual table line that will be returned by the server
+    '''
+
+    def __init__(self, params):
+        # Index of the line in the virtual table
+        self.index = -1
+        if TABLE_LINE_INDEX_KEY in params:
+            if params.get(TABLE_LINE_INDEX_KEY) is not None and type(params.get(TABLE_LINE_INDEX_KEY)) is int:
+                self.index = int(params.get(TABLE_LINE_INDEX_KEY))
+            del params[TABLE_LINE_INDEX_KEY]
+
+        # Array of cells in the line
+        self.cells = []
+        if TABLE_LINE_CELLS_KEY in params:
+            if params.get(TABLE_LINE_CELLS_KEY) is not None:
+                for cell in params.get(TABLE_LINE_CELLS_KEY):
+                    self.cells.append(VirtualTableLineCell(cell))
+            del params[TABLE_LINE_CELLS_KEY]
+
+    def print(self):
+
+        print(f"    index: {self.index}")
+        print("    cells:")
+        for i, cell in enumerate(self.cells):
+            cell.print()
+        print(f"    {'-' * 10}")
+
+class VirtualTableLineCell:
+    '''
+    Virtual table line cell that will be returned by the server
+    '''
+
+    def __init__(self, params):
+        # Content of the cell
+        self.content = None
+        if TABLE_LINE_CELL_CONTENT_KEY in params:
+            if params.get(TABLE_LINE_CELL_CONTENT_KEY) is not None:
+                self.content = params.get(TABLE_LINE_CELL_CONTENT_KEY)
+            del params[TABLE_LINE_CELL_CONTENT_KEY]
+
+    def print(self):
+        print(f"      \"{TABLE_LINE_CELL_CONTENT_KEY}\": \"{self.content}\"")

--- a/tsp/xy_model.py
+++ b/tsp/xy_model.py
@@ -58,7 +58,7 @@ class XYModel:
                 self.series.append(XYSeries(series))
             del params[SERIES_KEY]
 
-    def print(self):  # pragma: no cover
+    def print(self, array_print=False):  # pragma: no cover
         '''
         XY model rendering below
         '''
@@ -70,7 +70,7 @@ class XYModel:
         print(f'XY has common X axis: {common_x_axis}')
 
         for series in self.series:
-            series.print()
+            series.print(array_print)
 
 
 class XYSeries:
@@ -122,7 +122,7 @@ class XYSeries:
                 self.tags.append(tag)
             del params[TAGS_KEY]
 
-    def print(self):  # pragma: no cover
+    def print(self, array_print=False):  # pragma: no cover
         '''
         XY series rendering below
         '''
@@ -132,13 +132,18 @@ class XYSeries:
         if hasattr(self, 'x_axis'):
             print(f' Series X-axis:\n{self.x_axis.print()}')
             print(f' Series Y-axis:\n{self.y_axis.print()}')
-        for value in self.x_values:
-            print(f' Series X-value: {value}')
-        for value in self.y_values:
-            print(f' Series Y-value: {value}')
-        for tag in self.tags:
-            print(f' Series tag: {tag}')
-
+            
+        if not array_print:    
+            for value in self.x_values:
+                print(f' Series X-value: {value}')
+            for value in self.y_values:
+                print(f' Series Y-value: {value}')
+            for tag in self.tags:
+                print(f' Series tag: {tag}')
+        else:
+            print(f' Series X-values: {self.x_values}')
+            print(f' Series Y-values: {self.y_values}')
+            print(f' Series tags: {self.tags}')
 
 class XYAxis:
     '''

--- a/tsp_cli_client
+++ b/tsp_cli_client
@@ -196,8 +196,6 @@ if __name__ == "__main__":
                         help="Get the XY data of an output", metavar="OUTPUT_ID")
     parser.add_argument("--items", dest="items",
                         help="The list of XY items requested", nargs="*")
-    parser.add_argument("--times", dest="times",
-                        help="The list of XY times requested", nargs="*")
     parser.add_argument("--time-range", dest="time_range",
                         help="The time range requested", nargs=3)
     parser.add_argument("--uuid", dest="uuid", help="The UUID of a trace")
@@ -376,23 +374,23 @@ if __name__ == "__main__":
                 print("Provide requested --items for the XY data")
                 sys.exit(1)
 
-            if not options.times and not options.time_range:
-                print("Provide either requested --times or --time-range for the XY data")
+            if not options.time_range:
+                print("Provide requested --time-range for the XY data")
                 sys.exit(1)
 
             if options.uuid is not None:
-                parameters = {TspClient.REQUESTED_ITEM_KEY: list(map(int, options.items))}
-                if options.times:
-                    parameters[TspClient.REQUESTED_TIME_KEY] = list(map(int, options.times))
-                elif options.time_range:
-                    start_time = int(options.time_range[0])
-                    end_time = int(options.time_range[1])
-                    nb_times = int(options.time_range[2])
-                    parameters[TspClient.REQUESTED_TIME_RANGE_KEY] = {
+                start_time = int(options.time_range[0])
+                end_time = int(options.time_range[1])
+                nb_times = int(options.time_range[2])
+
+                parameters = {
+                    TspClient.REQUESTED_ITEM_KEY: list(map(int, options.items)),
+                    TspClient.REQUESTED_TIME_RANGE_KEY: {
                         TspClient.REQUESTED_TIME_RANGE_START_KEY: start_time,
                         TspClient.REQUESTED_TIME_RANGE_END_KEY: end_time,
                         TspClient.REQUESTED_TIME_RANGE_NUM_TIMES_KEY: nb_times
                     }
+                }
                 
                 params = {TspClient.PARAMETERS_KEY: parameters}
 
@@ -400,7 +398,7 @@ if __name__ == "__main__":
                     options.uuid, options.get_xy, params)
                 if response.status_code == 200:
                     xyModel = response.model.model
-                    xyModel.print(array_print=True if options.time_range else False)
+                    xyModel.print(array_print=True)
                     sys.exit(0)
                 else:
                     sys.exit(1)

--- a/tsp_cli_client
+++ b/tsp_cli_client
@@ -400,7 +400,7 @@ if __name__ == "__main__":
                     options.uuid, options.get_xy, params)
                 if response.status_code == 200:
                     xyModel = response.model.model
-                    xyModel.print()
+                    xyModel.print(array_print=True if options.time_range else False)
                     sys.exit(0)
                 else:
                     sys.exit(1)

--- a/tsp_cli_client
+++ b/tsp_cli_client
@@ -197,7 +197,7 @@ if __name__ == "__main__":
     parser.add_argument("--items", dest="items",
                         help="The list of XY items requested", nargs="*")
     parser.add_argument("--time-range", dest="time_range",
-                        help="The time range requested", nargs=3)
+                        help="The time range requested", nargs=3, metavar=("START", "END", "NUM_TIMES"))
     parser.add_argument("--uuid", dest="uuid", help="The UUID of a trace")
     parser.add_argument("--uuids", dest="uuids",
                         help="The list of UUIDs", nargs="*")

--- a/tsp_cli_client
+++ b/tsp_cli_client
@@ -198,6 +198,8 @@ if __name__ == "__main__":
                         help="The list of XY items requested", nargs="*")
     parser.add_argument("--times", dest="times",
                         help="The list of XY times requested", nargs="*")
+    parser.add_argument("--time-range", dest="time_range",
+                        help="The time range requested", nargs=3)
     parser.add_argument("--uuid", dest="uuid", help="The UUID of a trace")
     parser.add_argument("--uuids", dest="uuids",
                         help="The list of UUIDs", nargs="*")
@@ -370,13 +372,28 @@ if __name__ == "__main__":
             __get_tree(options.uuid, options.get_xy_tree, "TREE_TIME_XY")
 
         if options.get_xy:
-            if not options.items or not options.times:
-                print("Provide requested --items and --times for the XY data")
+            if not options.items:
+                print("Provide requested --items for the XY data")
+                sys.exit(1)
+
+            if not options.times and not options.time_range:
+                print("Provide either requested --times or --time-range for the XY data")
                 sys.exit(1)
 
             if options.uuid is not None:
-                parameters = {TspClient.REQUESTED_TIME_KEY: list(map(int, options.times)),
-                              TspClient.REQUESTED_ITEM_KEY: list(map(int, options.items))}
+                parameters = {TspClient.REQUESTED_ITEM_KEY: list(map(int, options.items))}
+                if options.times:
+                    parameters[TspClient.REQUESTED_TIME_KEY] = list(map(int, options.times))
+                elif options.time_range:
+                    start_time = int(options.time_range[0])
+                    end_time = int(options.time_range[1])
+                    nb_times = int(options.time_range[2])
+                    parameters[TspClient.REQUESTED_TIME_RANGE_KEY] = {
+                        TspClient.REQUESTED_TIME_RANGE_START_KEY: start_time,
+                        TspClient.REQUESTED_TIME_RANGE_END_KEY: end_time,
+                        TspClient.REQUESTED_TIME_RANGE_NUM_TIMES_KEY: nb_times
+                    }
+                
                 params = {TspClient.PARAMETERS_KEY: parameters}
 
                 response = tsp_client.fetch_xy(

--- a/tsp_cli_client
+++ b/tsp_cli_client
@@ -188,6 +188,20 @@ if __name__ == "__main__":
                         help="Get details on the given output of a trace", metavar="OUTPUT_ID")
     parser.add_argument("--get-tree", dest="get_tree",
                         help="Get the tree of an output of type DATA_TREE", metavar="OUTPUT_ID")
+    parser.add_argument("--get-virtual-table-lines", dest="get_virtual_table_lines",
+                        help="Get the tree lines of an output of type DATA_TREE", metavar="OUTPUT_ID")
+    parser.add_argument("--table-line-index", dest="table_line_index",
+                        help="The index of the table line to start fetching", metavar="TABLE_LINE_INDEX")
+    parser.add_argument("--table-line-count", dest="table_line_count",
+                        help="The number of table lines to fetch", metavar="TABLE_LINE_COUNT")
+    parser.add_argument("--table-times", dest="table_times",
+                        help="The list of times to fetch from table", nargs="*")
+    parser.add_argument("--table-column-ids", dest="table_column_ids",
+                        help="The list of column ids to fetch", nargs="*")
+    parser.add_argument("--table-search-direction", dest="table_search_direction",
+                        help="The direction to search for the table lines", metavar="TABLE_LINE_SEARCH_DIRECTION")
+    parser.add_argument("--table-search-expression", action="append", nargs=2, metavar=("COLUMN_ID", "EXPRESSION"), dest="table_search_expression",
+                        help="The column's expression to search for the table lines")
     parser.add_argument("--get-timegraph-tree", dest="get_timegraph_tree",
                         help="Get the tree of an output of type TIME_GRAPH", metavar="OUTPUT_ID")
     parser.add_argument("--get-xy-tree", dest="get_xy_tree",
@@ -399,6 +413,46 @@ if __name__ == "__main__":
                 if response.status_code == 200:
                     xyModel = response.model.model
                     xyModel.print(array_print=True)
+                    sys.exit(0)
+                else:
+                    sys.exit(1)
+            else:
+                print(TRACE_MISSING)
+                sys.exit(1)
+
+        if options.get_virtual_table_lines:
+            if options.uuid is not None:
+                if options.table_line_index is None and options.table_times is None:
+                    print("Provide at least one of requested --table-line-index or --table-times for the virtual table data")
+                    sys.exit(1)
+
+                if options.table_line_count is None:
+                    print("Provide requested --table-line-count for the virtual table data")
+                    sys.exit(1)
+
+                parameters = {
+                    TspClient.PARAMETERS_KEY: {
+                        TspClient.REQUESTED_TABLE_LINE_COUNT_KEY: int(options.table_line_count),
+                        TspClient.REQUESTED_TABLE_LINE_COLUMN_IDS_KEY: list(map(int, options.table_column_ids)) if options.table_column_ids is not None else [],
+                        TspClient.REQUESTED_TABLE_LINE_SEACH_DIRECTION_KEY: options.table_search_direction if options.table_search_direction is not None else "NEXT"
+                    }
+                }
+
+                if options.table_times is not None:
+                    parameters[TspClient.PARAMETERS_KEY][TspClient.REQUESTED_TIME_KEY] = list(map(int, options.table_times))
+                else:
+                    parameters[TspClient.PARAMETERS_KEY][TspClient.REQUESTED_TABLE_LINE_INDEX_KEY] = int(options.table_line_index)
+
+                if options.table_search_expression is not None:
+                    parameters[TspClient.PARAMETERS_KEY][TspClient.REQUESTED_TABLE_LINE_SEARCH_EXPRESSION_KEY] = {}
+                    for column_id, expression in options.table_search_expression:
+                        for column_id, expression in options.table_search_expression:
+                            parameters[TspClient.PARAMETERS_KEY][TspClient.REQUESTED_TABLE_LINE_SEARCH_EXPRESSION_KEY][str(column_id)] = str(expression)
+
+                response = tsp_client.fetch_virtual_table_lines(options.uuid, options.get_virtual_table_lines, parameters)
+                if response.status_code == 200:
+                    model = response.model.model
+                    model.print()
                     sys.exit(0)
                 else:
                     sys.exit(1)


### PR DESCRIPTION
Implementation of the get-virtual-table-lines in the tsp-python-client. The endpoint is already present in the [tsp-server](https://eclipse-cdt-cloud.github.io/trace-server-protocol/#tag/Virtual-Tables/operation/getLines). 