### PR TITLE
Add health endpoint API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ usage: tsp_cli_client [-h] [--ip IP] [--port PORT]
                       [--type-id TYPE_ID] 
                       [--config-id CONFIG_ID] 
                       [--params PARAMS]
+                      [--get-health]
 
 CLI client to send Trace Server Protocol commands to a Trace Server.
 
@@ -134,6 +135,7 @@ optional arguments:
   --config-id CONFIG_ID
                         id of configuration
   --params PARAMS       comma separated key value pairs (key1=val1,key2=val2)
+  --get-health          Get the health status of the server
 ```
 
 Examples:
@@ -161,6 +163,7 @@ Examples:
   ./tsp_cli_client --load-configuration --type-id TYPE_ID --params key1:value1
   ./tsp_cli_client --update-configuration --type-id TYPE_ID --config-id CONFIG_ID --params key1=value1,key2=value2
   ./tsp_cli_client --delete-configuration CONFIGURATION_ID --type-id TYPE_ID
+  ./tsp_cli_client --get-health
 ```
 
 [agc]: https://kislyuk.github.io/argcomplete/#activating-global-completion

--- a/test_tsp.py
+++ b/test_tsp.py
@@ -29,6 +29,7 @@ import uuid
 import pytest
 import requests
 
+from tsp.health import HealthStatus
 from tsp.response import ResponseStatus
 from tsp.tsp_client import TspClient
 
@@ -474,6 +475,13 @@ class TestTspClient:
         assert response.model.id == self.name
 
         self.tsp_client.delete_configuration(CONFIG_SOURCE_TYPE, self.name)
+
+    def test_fetch_health(self):
+        """Expect a successful health response"""
+        response = self.tsp_client.fetch_health()
+        assert response.status_code == 200
+        assert response.model
+        assert response.model.status == HealthStatus.UP
 
     @staticmethod
     def __requested_parameters(response):

--- a/tsp/health.py
+++ b/tsp/health.py
@@ -1,0 +1,62 @@
+# The MIT License (MIT)
+#
+# Copyright (C) 2024 - Ericsson
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Health class file."""
+
+from enum import Enum
+
+STATUS_KEY = "status"
+
+
+class HealthStatus(Enum):
+    '''
+    The server is running and ready to receive requests
+    '''
+    UP = "UP"
+
+    def __str__(self):
+        return f"{self.value}"
+
+
+# pylint: disable=too-few-public-methods
+class Health:
+    '''
+    Model of server health
+    '''
+
+    def __init__(self, params):
+        '''
+        Constructor
+        '''
+
+        # Health status
+        if STATUS_KEY in params:
+            self.status = HealthStatus(params.get(STATUS_KEY))
+            del params[STATUS_KEY]
+        else:
+            self.status = None
+
+    def to_string(self):
+        '''
+        to_string method
+        '''
+        return f"Health[status={self.status}]"

--- a/tsp/tsp_client.py
+++ b/tsp/tsp_client.py
@@ -37,6 +37,7 @@ from tsp.configuration_set import ConfigurationSet
 from tsp.experiment_set import ExperimentSet
 from tsp.experiment import Experiment
 from tsp.output_descriptor import OutputDescriptor
+from tsp.health import Health
 
 APPLICATION_JSON = 'application/json'
 
@@ -464,4 +465,19 @@ class TspClient:
                                      response.status_code, response.text)
         else:  # pragma: no cover
             print("post extension failed: {0}".format(response.status_code))
+            return TspClientResponse(None, response.status_code, response.text)
+
+    def fetch_health(self):
+        '''
+        Fetch the health status of the server
+        :return: :class:`TspClientResponse <Health>` object
+        :rtype: TspClientResponse
+        '''
+        api_url = '{0}health'.format(self.base_url)
+        response = requests.get(api_url, headers=headers)
+        if response.status_code == 200:
+            return TspClientResponse(Health(json.loads(response.content.decode('utf-8'))),
+                                     response.status_code, response.text)
+        else:  # pragma: no cover
+            print("get health failed: {0}".format(response.status_code))
             return TspClientResponse(None, response.status_code, response.text)

--- a/tsp_cli_client
+++ b/tsp_cli_client
@@ -222,6 +222,7 @@ if __name__ == "__main__":
     parser.add_argument("--type-id", dest="type_id", help="id of configuration source type")
     parser.add_argument("--config-id", dest="config_id", help="id of configuration")
     parser.add_argument("--params", dest="params", help="semicolon separated key value pairs (key1=val1;key2=val2)")
+    parser.add_argument("--get-health", dest="get_health", action='store_true', help="Get the health status of the server")
 
     argcomplete.autocomplete(parser)
     options = parser.parse_args()
@@ -510,6 +511,13 @@ if __name__ == "__main__":
             else:
                 print("No source typeId provided to delete this configuration")
 
+        if options.get_health:
+            response = tsp_client.fetch_health()
+            if response.status_code == 200:
+                print('  {0}'.format(response.model.to_string()))
+                sys.exit(0)
+            else:
+                sys.exit(1)
 
     except requests.exceptions.ConnectionError as e:
         print('Unexpected error: {0}'.format(e))


### PR DESCRIPTION
Add a fetch_health method to TspClient to allow a user to fetch the health status of the trace server as described in the TSP.

I have issues when running the tests locally, but I do not think they are related to the changes here.
I get these failures when running pytest:
```
FAILED test_tsp.py::TestTspClient::test_fetch_configurations_none - assert []                                                                                              
FAILED test_tsp.py::TestTspClient::test_posted_configuration_deleted - assert []
```

I am running the trace-server in a docker container built from the incubator commit ae0a7d93a6a2d6fa339f35ccd430e25dce1961c5 with only this repository mounted from the host, so it is possible that I am breaking some assumption.

Resolves #66 