### PR TITLE
Deserialize EntryHeader parameters

### DIFF
--- a/tree_model.py
+++ b/tree_model.py
@@ -54,7 +54,7 @@ class TreeModel:
         if self._headers is not None:
             headers = []
             for header in self._headers:
-                headers.append(header.name["name"])
+                headers.append(header.name)
             for child in self._root.get_children():
                 data = child.print(data, 0)
             frame = {}

--- a/tsp/entry.py
+++ b/tsp/entry.py
@@ -22,6 +22,8 @@
 
 """Entry classes file."""
 
+from enum import Enum
+
 from tsp.output_element_style import OutputElementStyle
 
 ID_KEY = "id"
@@ -29,11 +31,22 @@ PARENT_ID_KEY = "parentId"
 LABELS_KEY = "labels"
 STYLE_KEY = "style"
 HEADER_NAME_KEY = "name"
+HEADER_DATA_TYPE_KEY = "dataType"
+HEADER_TOOLTIP_KEY = "tooltip"
 UNKNOWN_ID = -1
-NAME_KEY = "name"
-TOOLTIP_KEY = "tooltip"
 
 # pylint: disable=too-few-public-methods
+
+class EntryHeaderDataType(Enum):
+    '''
+    The data types of a column entry.
+    '''
+    NUMBER = "NUMBER"
+    BINARY_NUMBER = "BINARY_NUMBER"
+    TIMESTAMP = "TIMESTAMP"
+    DURATION = "DURATION"
+    STRING = "STRING"
+    TIME_RANGE = "TIME_RANGE"
 
 
 class EntryHeader:
@@ -43,9 +56,29 @@ class EntryHeader:
 
     def __init__(self, params):
         '''
-        Displayed name
+        Constructor
         '''
-        self.name = params
+
+        # Name for this header.
+        if HEADER_NAME_KEY in params:
+            self.name = params.get(HEADER_NAME_KEY)
+            del params[HEADER_NAME_KEY]
+        else:
+            self.name = None
+
+        # Tooltip for this header.
+        if HEADER_TOOLTIP_KEY in params:
+            self.tooltip = params.get(HEADER_TOOLTIP_KEY)
+            del params[HEADER_TOOLTIP_KEY]
+        else:
+            self.tooltip = None
+
+        # Data type for this header.
+        if HEADER_DATA_TYPE_KEY in params:
+            self.data_type = EntryHeaderDataType(params.get(HEADER_DATA_TYPE_KEY))
+            del params[HEADER_DATA_TYPE_KEY]
+        else:
+            self.data_type = None
 
 
 class Entry:


### PR DESCRIPTION
The EntryHeader would set the map of all its parameters as its "name" member, which semantically does not make sense and requires a user to parse the name member itself to find the actual name (or other fields) of the header.

Deserialize the EntryHeader according to the TSP to set members "name", "tooltip" and "data_type".

The tests pass for me locally apart from these which also fails on master:
```
FAILED test_tsp.py::TestTspClient::test_fetch_configurations_none - assert []
FAILED test_tsp.py::TestTspClient::test_posted_configuration_deleted - assert []
```

Sidenote: I kept the naming consistent with the existing code, but I am not sure "EntryHeader" describes the class properly. The class "EntryHeader" does not contain a header for a single "Entry", it holds headers for all columns of an "Entry". I believe the naming in the openapi specification "TreeColumnHeader" describes it better. Perhaps here in Python it could be "ColumnHeader" or "EntryColumnHeader"? I could toss that into a separate PR if you agree.

Resolves #33 