### PR TITLE
add state and arrow requests

### DIFF
--- a/test_tsp.py
+++ b/test_tsp.py
@@ -41,6 +41,7 @@ TABLE_DP_ID = (
     "org.eclipse.tracecompass.analysis.timing.core.segmentstore.SegmentStoreTableDataProvider:"
     "org.eclipse.linuxtools.lttng2.ust.analysis.callstack"
 )
+TIMEGRAPH_DP_ID = "org.eclipse.tracecompass.internal.analysis.os.linux.core.threadstatus.ThreadStatusDataProvider"
 
 REQUESTED_TIME_START = 1332170682440133097
 REQUESTED_TIME_END = 1332170692664579801
@@ -501,6 +502,87 @@ class TestTspClient:
             for cell in line.cells:
                 assert cell.content is not None
 
+    def test_fetch_timegraph_states(self, kernel):
+        """Expect having states after tree is complete"""
+        traces = []
+        response = self.tsp_client.open_trace(os.path.basename(kernel), kernel)
+        traces.append(response.model.UUID)
+        response = self.tsp_client.open_experiment(
+            os.path.basename(kernel), traces)
+        assert response.status_code == 200
+        experiment_uuid = response.model.UUID
+
+        response = self.tsp_client.fetch_experiment_outputs(experiment_uuid)
+        output_id = TIMEGRAPH_DP_ID
+        status = ResponseStatus.RUNNING
+        while status == ResponseStatus.RUNNING:
+            time.sleep(1)
+            response = self.tsp_client.fetch_timegraph_tree(
+                experiment_uuid, output_id)
+            assert response.model is not None
+            status = response.model.status
+        entries = [entry.id for entry in response.model.model.entries if entry.has_row_model]
+        params = {
+            TspClient.REQUESTED_TIME_RANGE_KEY: {
+                TspClient.REQUESTED_TIME_RANGE_NUM_TIMES_KEY: 100,
+                TspClient.REQUESTED_TIME_RANGE_START_KEY: REQUESTED_TIME_START,
+                TspClient.REQUESTED_TIME_RANGE_END_KEY: REQUESTED_TIME_END
+            },
+            TspClient.REQUESTED_ITEM_KEY: entries
+        }
+        response = self.tsp_client.fetch_timegraph_states(
+            experiment_uuid, output_id,  { TspClient.PARAMETERS_KEY: params })
+        assert response.status_code == 200
+        assert len(response.model.model.rows) > 0
+        assert len(response.model.model.rows[0].states) != 0
+        row = response.model.model.rows[0].states[0]
+        assert row.start_time is not None
+        assert row.end_time is not None
+        self._delete_experiments()
+        self._delete_traces()
+
+    def test_fetch_timegraph_arrows(self, kernel):
+        """Expect having arrows after tree is complete"""
+        traces = []
+        response = self.tsp_client.open_trace(os.path.basename(kernel), kernel)
+        traces.append(response.model.UUID)
+        response = self.tsp_client.open_experiment(
+            os.path.basename(kernel), traces)
+        assert response.status_code == 200
+        experiment_uuid = response.model.UUID
+
+        response = self.tsp_client.fetch_experiment_outputs(experiment_uuid)
+        output_id = TIMEGRAPH_DP_ID
+        status = ResponseStatus.RUNNING
+        while status == ResponseStatus.RUNNING:
+            time.sleep(1)
+            response = self.tsp_client.fetch_timegraph_tree(
+                experiment_uuid, output_id)
+            assert response.model is not None
+            status = response.model.status
+
+        entries = [entry.id for entry in response.model.model.entries if entry.has_row_model]
+        params = {
+            TspClient.REQUESTED_TIME_RANGE_KEY: {
+                TspClient.REQUESTED_TIME_RANGE_NUM_TIMES_KEY: 5000,
+                TspClient.REQUESTED_TIME_RANGE_START_KEY: REQUESTED_TIME_START,
+                TspClient.REQUESTED_TIME_RANGE_END_KEY: REQUESTED_TIME_END
+            },
+            TspClient.REQUESTED_ITEM_KEY: entries
+        }
+        response = self.tsp_client.fetch_timegraph_arrows(
+            experiment_uuid, output_id, { TspClient.PARAMETERS_KEY: params })
+        assert response.status_code == 200
+        assert len(response.model.model) != 0
+        arrow = response.model.model[0]
+        assert arrow.source_id is not None
+        assert arrow.target_id is not None
+        if arrow.start is None or arrow.end is None:
+            assert arrow.duration
+        else:
+            assert arrow.start is not None
+            assert arrow.end is not None
+        assert arrow.style is not None
         self._delete_experiments()
         self._delete_traces()
 

--- a/tsp/model_type.py
+++ b/tsp/model_type.py
@@ -31,8 +31,9 @@ class ModelType(Enum):
     '''
 
     TIME_GRAPH_TREE = "time_graph_tree"
+    TIME_GRAPH_STATE = "time_graph_state"
+    TIME_GRAPH_ARROW = "time_graph_arrow"
     XY_TREE = "xy_tree"
-    STATES = "states"
     XY = "xy"
     DATA_TREE = "data_tree"
     VIRTUAL_TABLE_HEADER = "virtual_table_header"

--- a/tsp/response.py
+++ b/tsp/response.py
@@ -30,6 +30,7 @@ from tsp.entry_model import EntryModel
 from tsp.virtual_table_header_model import VirtualTableHeaderModel
 from tsp.xy_model import XYModel
 from tsp.virtual_table_model import VirtualTableModel
+from tsp.time_graph_model import TimeGraphModel, TimeGraphArrow
 
 MODEL_KEY = "model"
 OUTPUT_DESCRIPTOR_KEY = "output"
@@ -81,10 +82,15 @@ class GenericResponse:
         if MODEL_KEY in params and params.get(MODEL_KEY) is not None:
             if self.model_type == ModelType.TIME_GRAPH_TREE:
                 self.model = EntryModel(params.get(MODEL_KEY), self.model_type)
+            elif self.model_type == ModelType.TIME_GRAPH_STATE:
+                self.model = TimeGraphModel(params.get(MODEL_KEY))
+            elif self.model_type == ModelType.TIME_GRAPH_ARROW:
+                arrows = []
+                for arrow in params.get(MODEL_KEY):
+                    arrows.append(TimeGraphArrow(arrow))
+                self.model = arrows
             elif self.model_type == ModelType.XY_TREE:
                 self.model = EntryModel(params.get(MODEL_KEY))
-            elif self.model_type == ModelType.STATES:  # pragma: no cover
-                print("not implemented")
             elif self.model_type == ModelType.XY:
                 self.model = XYModel(params.get(MODEL_KEY))
             elif self.model_type == ModelType.DATA_TREE:

--- a/tsp/time_graph_model.py
+++ b/tsp/time_graph_model.py
@@ -25,19 +25,19 @@
 from tsp.entry import Entry
 
 TYPE_KEY = "type"
-START_TIME_KEY = "startTime"
-END_TIME_KEY = "endTime"
-HAS_ROW_MODEL_KEY = "hasRowModel"
+START_TIME_KEY = "start"
+END_TIME_KEY = "end"
+HAS_ROW_MODEL_KEY = "hasData"
 ROWS_KEY = "rows"
-ENTRY_ID_KEY = "entryID"
+ENTRY_ID_KEY = "entryId"
 STATES_KEY = "states"
 DURATION_KEY = "duration"
 LABEL_KEY = "label"
-VALUE_KEY = "value"
+VALUE_KEY = "values"
 TAGS_KEY = "tags"
 STYLE_KEY = "style"
 SOURCE_ID_TAG = "sourceId"
-DESTINATION_ID_TAG = "destinationId"
+TARGET_ID_TAG = "targetId"
 
 # pylint: disable=too-few-public-methods
 
@@ -119,9 +119,9 @@ class TimeGraphState:
             del params[START_TIME_KEY]
 
         # Duration of the state
-        if DURATION_KEY in params:
-            self.duration = params.get(DURATION_KEY)
-            del params[DURATION_KEY]
+        if END_TIME_KEY in params:
+            self.end_time = params.get(END_TIME_KEY)
+            del params[END_TIME_KEY]
 
         # Label to apply to the state
         if LABEL_KEY in params:
@@ -158,14 +158,19 @@ class TimeGraphArrow:
             del params[SOURCE_ID_TAG]
 
         # Destination entry Id for the arrow
-        if DESTINATION_ID_TAG in params:
-            self.destination_id = params.get(DESTINATION_ID_TAG)
-            del params[DESTINATION_ID_TAG]
+        if TARGET_ID_TAG in params:
+            self.target_id = params.get(TARGET_ID_TAG)
+            del params[TARGET_ID_TAG]
 
         # Start time of the arrow
         if START_TIME_KEY in params:
-            self.start_time = params.get(START_TIME_KEY)
+            self.start = params.get(START_TIME_KEY)
             del params[START_TIME_KEY]
+
+        # Duration of the state
+        if END_TIME_KEY in params:
+            self.end = params.get(END_TIME_KEY)
+            del params[END_TIME_KEY]
 
         # Duration of the arrow
         if DURATION_KEY in params:

--- a/tsp/tsp_client.py
+++ b/tsp/tsp_client.py
@@ -47,6 +47,9 @@ headers_form = {'content-type': 'application/x-www-form-urlencoded',
                 'Accept': APPLICATION_JSON}
 
 GET_TREE_FAILED = "failed to get tree: {0}"
+GET_STATES_FAILED = "failed to get states: {0}"
+GET_ARROWS_FAILED = "failed to get arrows: {0}"
+
 
 # pylint: disable=consider-using-f-string,missing-timeout
 
@@ -346,12 +349,13 @@ class TspClient:
         :returns: :class:  `TspClientResponse <GenericResponse>` object Timegraph entries response
         :rtype: TspClientResponse
         '''
-        api_url = '{0}experiments/{1}/outputs/timeGraph/{2}/tree'.format(
-            self.base_url, exp_uuid, output_id)
+        api_url = f'{self.base_url}experiments/{exp_uuid}/outputs/timeGraph/{output_id}/tree'
 
         params = parameters
         if parameters is None:
-            params = {}
+            params = {
+                "parameters": { }
+            }
 
         response = requests.post(api_url, json=params, headers=headers)
 
@@ -361,6 +365,62 @@ class TspClient:
                                      response.status_code, response.text)
         else:  # pragma: no cover
             print(GET_TREE_FAILED.format(response.status_code))
+            return TspClientResponse(None, response.status_code, response.text)
+
+
+    def fetch_timegraph_states(self, exp_uuid, output_id, parameters=None):
+        '''
+        Fetch Time Graph States
+        :param exp_uuid: Experiment UUID
+        :param output_id: Output ID
+        :param parameters: Query object
+        :returns: :class:  `TspClientResponse <GenericResponse>` object Timegraph Model response
+        :rtype: TspClientResponse
+        '''
+        api_url = f'{self.base_url}experiments/{exp_uuid}/outputs/timeGraph/{output_id}/states'
+
+        params = parameters
+        if parameters is None:
+            params = {
+                "parameters": { }
+            }
+
+        response = requests.post(api_url, json=params, headers=headers)
+
+        if response.status_code == 200:
+            return TspClientResponse(GenericResponse(json.loads(response.content.decode('utf-8')),
+                                                     ModelType.TIME_GRAPH_STATE),
+                                     response.status_code, response.text)
+        else:  # pragma: no cover
+            print(GET_STATES_FAILED.format(response.status_code))
+            return TspClientResponse(None, response.status_code, response.text)
+
+
+    def fetch_timegraph_arrows(self, exp_uuid, output_id, parameters=None):
+        '''
+        Fetch Time Graph Arrows
+        :param exp_uuid: Experiment UUID
+        :param output_id: Output ID
+        :param parameters: Query object
+        :returns: :class:  `TspClientResponse <GenericResponse>` list of object Timegraph arrows response
+        :rtype: TspClientResponse
+        '''
+        api_url = f'{self.base_url}experiments/{exp_uuid}/outputs/timeGraph/{output_id}/arrows'
+
+        params = parameters
+        if parameters is None:
+            params = {
+                "parameters": { }
+            }
+
+        response = requests.post(api_url, json=params, headers=headers)
+
+        if response.status_code == 200:
+            return TspClientResponse(GenericResponse(json.loads(response.content.decode('utf-8')),
+                                                     ModelType.TIME_GRAPH_ARROW),
+                                     response.status_code, response.text)
+        else:  # pragma: no cover
+            print(GET_ARROWS_FAILED.format(response.status_code))
             return TspClientResponse(None, response.status_code, response.text)
 
     def fetch_xy_tree(self, exp_uuid, output_id, parameters=None):
@@ -377,7 +437,9 @@ class TspClient:
 
         params = parameters
         if parameters is None:
-            params = {}
+            params = {
+                "parameters": { }
+            }
 
         response = requests.post(api_url, json=params, headers=headers)
 
@@ -401,7 +463,12 @@ class TspClient:
         api_url = '{0}experiments/{1}/outputs/XY/{2}/xy'.format(
             self.base_url, exp_uuid, output_id)
 
-        response = requests.post(api_url, json=parameters, headers=headers)
+        params = parameters
+        if parameters is None:
+            params = {
+                "parameters": { }
+            }
+        response = requests.post(api_url, json=params, headers=headers)
 
         if response.status_code == 200:
             return TspClientResponse(GenericResponse(json.loads(response.content.decode('utf-8')),


### PR DESCRIPTION
This pull request add the implementation for the arrows and states routes.

This change follows the following TSP specification:
- https://eclipse-cdt-cloud.github.io/trace-server-protocol/#tag/TimeGraph/operation/getStates
- https://eclipse-cdt-cloud.github.io/trace-server-protocol/#tag/TimeGraph/operation/getArrows