### PR TITLE
add slash if not existant in base url

### DIFF
--- a/test_tsp.py
+++ b/test_tsp.py
@@ -120,6 +120,13 @@ class TestTspClient:
         self._delete_experiments()
         self._delete_traces()
 
+    def test_fetch_with_other_client(self):
+        """Expect client without end slash to respond with no traces"""
+        tsp_client = TspClient('http://localhost:8080/tsp/api')
+        response = tsp_client.fetch_traces()
+        assert response.status_code == 200
+        assert not response.model.traces
+
     def test_fetch_traces_none(self):
         """Expect no traces without opening any."""
         response = self.tsp_client.fetch_traces()

--- a/tsp/tsp_client.py
+++ b/tsp/tsp_client.py
@@ -67,7 +67,7 @@ class TspClient:
         '''
         Constructor
         '''
-        self.base_url = base_url
+        self.base_url = base_url if base_url.endswith('/') else base_url + '/'
 
     def fetch_traces(self):
         '''


### PR DESCRIPTION
This adds a slash if one is not added in the configured value. It removes one possibility of user error.