### PR TITLE
Fix configuration tests if server has no preloaded configurations

### DIFF
--- a/test_tsp.py
+++ b/test_tsp.py
@@ -422,7 +422,7 @@ class TestTspClient:
         """Expect no configurations without posting any."""
         response = self.tsp_client.fetch_configurations(CONFIG_SOURCE_TYPE)
         assert response.status_code == 200
-        assert response.model.configuration_set
+        assert response.model.configuration_set == []
 
         response = self.tsp_client.fetch_configuration(CONFIG_SOURCE_TYPE, self.name)
         assert response.status_code == 404
@@ -461,7 +461,7 @@ class TestTspClient:
         assert response.status_code == 200
 
         response = self.tsp_client.fetch_configurations(CONFIG_SOURCE_TYPE)
-        assert response.model.configuration_set
+        assert response.model.configuration_set == []
 
     def test_put_configuration(self, extension):
         """Expect successful update of configuartion."""


### PR DESCRIPTION
Fixes the following failures if the server used for the tests contains pre-loaded configurations.

FAILED test_tsp.py::TestTspClient::test_fetch_configurations_none - assert []
FAILED test_tsp.py::TestTspClient::test_posted_configuration_deleted - assert []

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>