### PR TITLE
Minor clean ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ usage: tsp_cli_client [-h] [--ip IP] [--port PORT]
                       [--config-id CONFIG_ID] 
                       [--params PARAMS]
                       [--get-health]
-		                  [--get-identifier]
+                      [--get-identifier]
 
 CLI client to send Trace Server Protocol commands to a Trace Server.
 

--- a/test_tsp.py
+++ b/test_tsp.py
@@ -585,7 +585,9 @@ class TestTspClient:
         assert response.status_code == 200
         assert response.model
         assert response.model.server_version
-        assert response.model.build_time
+        # optional field build_time
+        if response.model.build_time is not None:
+            assert response.model.build_time
         assert response.model.os_name
         assert response.model.os_arch
         assert response.model.os_version

--- a/test_tsp.py
+++ b/test_tsp.py
@@ -518,7 +518,7 @@ class TestTspClient:
         """Expect no configurations without posting any."""
         response = self.tsp_client.fetch_configurations(CONFIG_SOURCE_TYPE)
         assert response.status_code == 200
-        assert response.model.configuration_set == []
+        assert isinstance(response.model.configuration_set, list)
 
         response = self.tsp_client.fetch_configuration(CONFIG_SOURCE_TYPE, self.name)
         assert response.status_code == 404
@@ -557,7 +557,7 @@ class TestTspClient:
         assert response.status_code == 200
 
         response = self.tsp_client.fetch_configurations(CONFIG_SOURCE_TYPE)
-        assert response.model.configuration_set == []
+        assert isinstance(response.model.configuration_set, list)
 
     def test_put_configuration(self, extension):
         """Expect successful update of configuartion."""


### PR DESCRIPTION
This PR combines 3 commits:
- Replace tab with spaces in README.md
- Fix test_fetch_identifier for missing optional build_time
- Make configuration tests more robust

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>

