### PR TITLE
Get tags for virtual table lines and cells

### DIFF
--- a/test_tsp.py
+++ b/test_tsp.py
@@ -497,12 +497,12 @@ class TestTspClient:
             assert line.index is not None
             if i == 0:
                 assert line.index == LOW_INDEX
-            assert line.tags is VirtualTableTag.NO_TAGS
+            assert line.tags == VirtualTableTag.NO_TAGS
 
             assert len(line.cells) > 0
             for cell in line.cells:
                 assert cell.content is not None
-                assert cell.tags is VirtualTableTag.NO_TAGS
+                assert cell.tags == VirtualTableTag.NO_TAGS
 
         self._delete_experiments()
         self._delete_traces()

--- a/test_tsp.py
+++ b/test_tsp.py
@@ -32,6 +32,7 @@ import requests
 from tsp.health import HealthStatus
 from tsp.response import ResponseStatus
 from tsp.tsp_client import TspClient
+from tsp.virtual_table_tag import VirtualTableTag
 
 STATISTICS_DP_ID = (
     "org.eclipse.tracecompass.analysis.timing.core.segmentstore.SegmentStoreStatisticsDataProvider:"
@@ -496,10 +497,12 @@ class TestTspClient:
             assert line.index is not None
             if i == 0:
                 assert line.index == LOW_INDEX
+            assert line.tags is VirtualTableTag.NO_TAGS
 
             assert len(line.cells) > 0
             for cell in line.cells:
                 assert cell.content is not None
+                assert cell.tags is VirtualTableTag.NO_TAGS
 
         self._delete_experiments()
         self._delete_traces()

--- a/tsp/virtual_table_model.py
+++ b/tsp/virtual_table_model.py
@@ -22,10 +22,13 @@
 
 """VirtualTableModel class file."""
 
+from tsp.virtual_table_tag import VirtualTableTag
+
 SIZE_KEY = "size"
 LOW_INDEX_KEY = "lowIndex"
 COLUMN_IDS_KEY = "columnIds"
 LINES_KEY = "lines"
+TAGS_KEY = "tags"
 
 TABLE_LINE_INDEX_KEY = "index"
 TABLE_LINE_CELLS_KEY = "cells"
@@ -99,13 +102,32 @@ class VirtualTableLine:
                     self.cells.append(VirtualTableLineCell(cell))
             del params[TABLE_LINE_CELLS_KEY]
 
+        self.tags = VirtualTableTag.NO_TAGS
+        if TAGS_KEY in params:
+            if params.get(TAGS_KEY) is not None and type(params.get(TAGS_KEY)) is int:
+                tags = int(params.get(TAGS_KEY))
+
+                match tags:
+                    case 0: # Tag 0 is used for no tags
+                        self.tags = VirtualTableTag.NO_TAGS
+                    case 1 | 2: # Tags 1 and 2 are reserved
+                        self.tags = VirtualTableTag.RESERVED
+                    case 4: # Tag 4 is used for border
+                        self.tags = VirtualTableTag.BORDER
+                    case 8: # Tag 8 is used for highlight
+                        self.tags = VirtualTableTag.HIGHLIGHT
+                    case _: # Other tags are not supported
+                        self.tags = VirtualTableTag.NO_TAGS
+            del params[TAGS_KEY]
+
     def print(self):
 
         print(f"    index: {self.index}")
+        print(f"    tags: {self.tags.name}")
         print("    cells:")
         for i, cell in enumerate(self.cells):
             cell.print()
-        print(f"    {'-' * 10}")
+        print(f"    {'-' * 30}")
 
 class VirtualTableLineCell:
     '''
@@ -120,5 +142,25 @@ class VirtualTableLineCell:
                 self.content = params.get(TABLE_LINE_CELL_CONTENT_KEY)
             del params[TABLE_LINE_CELL_CONTENT_KEY]
 
+        self.tags = VirtualTableTag.NO_TAGS
+        if TAGS_KEY in params:
+            if params.get(TAGS_KEY) is not None and type(params.get(TAGS_KEY)) is int:
+                tags = int(params.get(TAGS_KEY))
+
+                match tags:
+                    case 0: # Tag 0 is used for no tags
+                        self.tags = VirtualTableTag.NO_TAGS
+                    case 1 | 2: # Tags 1 and 2 are reserved
+                        self.tags = VirtualTableTag.RESERVED
+                    case 4: # Tag 4 is used for border
+                        self.tags = VirtualTableTag.BORDER
+                    case 8: # Tag 8 is used for highlight
+                        self.tags = VirtualTableTag.HIGHLIGHT
+                    case _: # Other tags are not supported
+                        self.tags = VirtualTableTag.NO_TAGS
+            del params[TAGS_KEY]
+
     def print(self):
         print(f"      \"{TABLE_LINE_CELL_CONTENT_KEY}\": \"{self.content}\"")
+        print(f"      \"tags\": {self.tags.name}")
+        print(f"    {'-' * 10}")

--- a/tsp/virtual_table_tag.py
+++ b/tsp/virtual_table_tag.py
@@ -1,0 +1,27 @@
+from enum import Enum
+
+class VirtualTableTag(Enum):
+    '''
+    Tag is a bit mask to apply for tagging elements (e.g. table lines, states).
+    This can be used by the server to indicate if a filter matches and what action to apply.
+    '''
+
+    '''
+    Simply no tags
+    '''
+    NO_TAGS = 'NO_TAGS'
+
+    '''
+    Some tags are reserved for the server
+    '''
+    RESERVED = 'RESERVED'
+
+    '''
+    Border tag
+    '''
+    BORDER = 'BORDER'
+
+    '''
+    Highlight tag
+    '''
+    HIGHLIGHT = 'HIGHLIGHT'

--- a/tsp/virtual_table_tag.py
+++ b/tsp/virtual_table_tag.py
@@ -1,6 +1,6 @@
-from enum import Enum
+from enum import Flag, auto
 
-class VirtualTableTag(Enum):
+class VirtualTableTag(Flag):
     '''
     Tag is a bit mask to apply for tagging elements (e.g. table lines, states).
     This can be used by the server to indicate if a filter matches and what action to apply.
@@ -9,19 +9,20 @@ class VirtualTableTag(Enum):
     '''
     Simply no tags
     '''
-    NO_TAGS = 'NO_TAGS'
+    NO_TAGS = 0
 
     '''
     Some tags are reserved for the server
     '''
-    RESERVED = 'RESERVED'
+    RESERVED_1 = auto()
+    RESERVED_2 = auto()
 
     '''
     Border tag
     '''
-    BORDER = 'BORDER'
+    BORDER = auto()
 
     '''
     Highlight tag
     '''
-    HIGHLIGHT = 'HIGHLIGHT'
+    HIGHLIGHT = auto()


### PR DESCRIPTION
With respect to the following feature in trace-server:
```java
@Schema(description = "Tags for the entire line. " +
        "A bit mask to apply for tagging elements (e.g. table lines, states). " +
        "This can be used by the server to indicate if a filter matches and what action to apply. " +
        "Use 0 for no tags, 1 and 2 are reserved, 4 for 'BORDER' and 8 for 'HIGHLIGHT'.")
int getTags();
```

We can now get the corresponding tags for both lines and cells.
```
0 -> NO_TAGS
1 & 2 -> RESERVED
4 -> BORDER
8 -> HIGHLIGHT
```

