### PR TITLE
GenericResponse status message assignment fix

### DIFF
--- a/tsp/response.py
+++ b/tsp/response.py
@@ -108,6 +108,6 @@ class GenericResponse:
 
         # Message associated with the response
         if STATUS_MESSAGE_KEY in params:
-            self.status = params.get(STATUS_MESSAGE_KEY)
+            self.status_text = params.get(STATUS_MESSAGE_KEY)
         else:  # pragma: no cover
-            self.status = ""
+            self.status_text = ""


### PR DESCRIPTION
Handling correct assignment of the `status message` to `GenericResponse`'s `status text` instead of overwriting the `status` parameter.