### PR TITLE
[CI] Add workflow that runs the tests

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  Setup-and-Test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Install Trace Server
+        run: curl -o trace-compass-server.tar.gz https://download.eclipse.org/tracecompass.incubator/trace-server/rcp/trace-compass-server-latest-linux.gtk.x86_64.tar.gz; tar -xf trace-compass-server.tar.gz
+      - name: Start Trace Server
+        run: nohup ./trace-compass-server/tracecompass-server&
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x' 
+      - name: Set up virtual environment
+        run: python3 -m venv .venv
+      - name: Install dependencies
+        run: |
+          source .venv/bin/activate
+          pip install -r requirements.txt
+      - name: Run tests
+        run: |
+          .venv/bin/pytest


### PR DESCRIPTION
Since this repo already has tests, it was a low-hanging fruit to run them in CI. The new workflow basically follows the test instructions from the repo's README. Since a trace server is needed, the latest build is fetched, installed and started, before the tests are run.

The new workflow is expected to fail momentarily, until the following PR is merged and a new trace server including it is available:
https://github.com/eclipse-tracecompass-incubator/org.eclipse.tracecompass.incubator/pull/73