### PR TITLE
Add parameter "properties" in class Trace

### DIFF
--- a/test_tsp.py
+++ b/test_tsp.py
@@ -208,6 +208,39 @@ class TestTspClient:
         self._delete_experiments()
         self._delete_traces()
 
+    def test_opened_trace_info(self, kernel, other):
+        """Expect the info of the trace correctly set."""
+        traces = []
+        response = self.tsp_client.open_trace(os.path.basename(kernel), kernel)
+        traces.append(response.model.UUID)
+
+        # The trace info in read after it is opened in an
+        # experiment, so open the experiment here.
+        response = self.tsp_client.open_experiment(
+            os.path.basename(kernel), traces)
+        assert response.status_code == 200
+
+        trace = response.model.traces.traces[0]
+        assert trace.start == 1332170682440133097
+        assert trace.end == 1332170682702071857
+        assert trace.path.endswith('/tracecompass-test-traces/ctf/src/main/resources/kernel')
+        assert isinstance(trace.properties, dict)
+        assert len(trace.properties) == 11
+        assert trace.properties["clock_offset"] == '1332166405241713987'
+        assert trace.properties["clock_scale"] == '1.0'
+        assert trace.properties["domain"] == '"kernel"'
+        assert trace.properties["host ID"] == '"84db105b-b3f4-4821-b662-efc51455106a"'
+        assert trace.properties['tracer_name'] == '"lttng-modules"'
+        assert trace.properties['tracer_major'] == '2'
+        assert trace.properties['tracer_minor'] == '0'
+        assert trace.properties['kernel_release'] == '"3.0.0-16-generic-pae"'
+        assert trace.properties['sysname'] == '"Linux"'
+        assert trace.properties['tracer_patchlevel'] == '0'
+        assert trace.properties['kernel_version'] == '"#29-Ubuntu SMP Tue Feb 14 13:56:31 UTC 2012"'
+
+        self._delete_experiments()
+        self._delete_traces()
+
     def test_open_experiment_unopened_trace(self, kernel):
         """Expect 204 after opening experiment with unopened trace."""
         traces = []

--- a/tsp/trace.py
+++ b/tsp/trace.py
@@ -33,6 +33,7 @@ END_TIME_KEY = "end"
 PATH_KEY = "path"
 NB_EVENT_KEY = "nbEvents"
 PATH_TIME_KEY = "path"
+PROPERTIES_KEY = "properties"
 INDEXING_STATUS_KEY = "indexingStatus"
 
 
@@ -90,6 +91,13 @@ class Trace:
             del params[NB_EVENT_KEY]
         else:  # pragma: no cover
             self.number_of_events = 0
+
+        # Properties of the trace
+        if PROPERTIES_KEY in params:
+            self.properties = params.get(PROPERTIES_KEY)
+            del params[PROPERTIES_KEY]
+        else:  # pragma: no cover
+            self.properties = {}
 
         # Indicate if the indexing of the trace is completed or still running.
         # If it still running, the end time and number of events are not final

--- a/tsp_cli_client
+++ b/tsp_cli_client
@@ -66,9 +66,9 @@ def __print_experiment(elem):
 
 
 def __print_trace(elem):
-    print('    {0}: {1} ({2}) start={3} end={4} nbEvents={5} indexing={6}'.format(
+    print('    {0}: {1} ({2}) start={3} end={4} nbEvents={5} properties={6} indexing={7}'.format(
         elem.name, elem.path, __print_uuid(elem), elem.start, elem.end,
-        elem.number_of_events, elem.indexing_status))
+        elem.number_of_events, elem.properties, elem.indexing_status))
 
 
 def __print_output(output):


### PR DESCRIPTION
Add the parameter "properties" introduced by commit 499408e3979cab403a5d58 in the server (incubator).

Link to the PR for the commit: https://github.com/eclipse-tracecompass-incubator/org.eclipse.tracecompass.incubator/pull/79

Signed-off-by: Siwei Zhang <siwei.zhang@ericsson.com>