### PR TITLE
[CI] run ci-cd workflow nightly

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - master
+  schedule:
+    - cron: '0 2 * * *' # Runs every day at 2am: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule
 
 jobs:
   Setup-and-Test:


### PR DESCRIPTION
This should help detect if changes in the latest published trace server interfere with the tsp-python-client.