### PR TITLE
Add JSON encoders, string and JSON representation for various classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Examples:
   ./tsp_cli_client --list-experiment UUID
   ./tsp_cli_client --delete-experiment UUID [--do-delete-traces]
   ./tsp_cli_client --list-outputs UUID
+  ./tsp_cli_client --list-output OUTPUT_ID --uuid UUID
   ./tsp_cli_client --get-tree OUTPUT_ID --uuid UUID
   ./tsp_cli_client --get-virtual-table-columns OUTPUT_ID --uuid UUID
   ./tsp_cli_client --get-virtual-table-lines --table-line-index INDEX --table-line-count COUNT --table-column-ids IDs --table-search-direction DIRECTION --table-search-expression COLUMN_ID EXPRESSION

--- a/tsp/configuration.py
+++ b/tsp/configuration.py
@@ -22,8 +22,10 @@
 
 """Configuration class file."""
 
+import json
+
 NAME_KEY = "name"
-DESCTIPION_KEY = "description"
+DESCRIPTION_KEY = "description"
 ID_KEY = "id"
 SOURCE_TYPE_ID = "sourceTypeId"
 PARAMETER_KEY = "parameters"
@@ -44,9 +46,9 @@ class Configuration:
         else:
             self.name = ""
 
-        if DESCTIPION_KEY in params:
-            self.description = params.get(DESCTIPION_KEY)
-            del params[DESCTIPION_KEY]
+        if DESCRIPTION_KEY in params:
+            self.description = params.get(DESCRIPTION_KEY)
+            del params[DESCRIPTION_KEY]
         else:
             self.description = ""
 
@@ -71,11 +73,23 @@ class Configuration:
         else:
             self.parameters = {}
 
+    def __repr__(self):
+        return 'Configuration(name={}, description={}, id={}, source_type_id={}, parameters={})'.format(
+            self.name, self.description, self.id, self.source_type_id, self.parameters)
 
-    # pylint: disable=consider-using-f-string
-    def to_string(self):
-        '''
-        to_string method
-        '''
-        return 'Configuration[name={0}, description={1}, id={2}, source_type_id={3}, parameters={4}]'.format(self.name,
-          self.description, self.id, self.source_type_id, self.parameters)
+    def to_json(self):
+        return json.dumps(self, cls=ConfigurationEncoder, indent=4)
+
+
+class ConfigurationEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, Configuration):
+            return {
+                ID_KEY: obj.id,
+                NAME_KEY: obj.name,
+                DESCRIPTION_KEY: obj.description,
+                SOURCE_TYPE_ID: obj.source_type_id,
+                PARAMETER_KEY: obj.parameters
+            }
+        return super().default(obj)
+

--- a/tsp/configuration_parameter_descriptor.py
+++ b/tsp/configuration_parameter_descriptor.py
@@ -22,6 +22,8 @@
 
 """Configuration parameter descriptors class file."""
 
+import json
+
 KEY_NAME_KEY = "keyName"
 DESCTIPION_KEY = "description"
 DATA_TYPE_KEY = "dataType"
@@ -61,13 +63,23 @@ class ConfigurationParameterDescriptor:
             self.is_required = params.get(REQUIRED_KEY)
             del params[REQUIRED_KEY]
         else:
-            self.is_required = "unknown_source_type_id"
+            self.is_required = "false"
+
+    def __repr__(self):
+        return 'ConfigurationParameterDescriptor[key_name={}, description={}, data_type={}, is_required={}])'.format(
+            self.key_name,self.description, self.data_type, self.is_required)
+
+    def to_json(self):
+        return (json.dumps(self, cls=ConfigurationParameterDescriptorEncoder, indent=4))
 
 
-    # pylint: disable=consider-using-f-string
-    def to_string(self):
-        '''
-        to_string method
-        '''
-        return 'ConfigurationParameterDescriptor[key_name={0}, description={1}, data_type={2}, is_required={3}]'.format(self.key_name,
-          self.description, self.data_type, self.is_required)
+class ConfigurationParameterDescriptorEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, ConfigurationParameterDescriptor):
+            return {
+                KEY_NAME_KEY: obj.key_name,
+                DESCTIPION_KEY: obj.description,
+                DATA_TYPE_KEY: obj.data_type,
+                REQUIRED_KEY: obj.is_required
+            }
+        return super().default(obj)

--- a/tsp/configuration_parameter_descriptor_set.py
+++ b/tsp/configuration_parameter_descriptor_set.py
@@ -22,7 +22,8 @@
 
 """ConfigurationSet class file."""
 
-from tsp.configuration_parameter_descriptor import ConfigurationParameterDescriptor
+import json
+from tsp.configuration_parameter_descriptor import ConfigurationParameterDescriptor, ConfigurationParameterDescriptorEncoder
 
 
 # pylint: disable=too-few-public-methods
@@ -39,16 +40,17 @@ class ConfigurationParameterDescriptorSet:
         for obj in params:
             self.configuration_parameter_set.append(ConfigurationParameterDescriptor(obj))
 
+    def __repr__(self) -> str:
+        return 'ConfigurationParameterDescriptorSet({})'.format(', '.join(str(source) for source in self.configuration_parameter_set))
 
-    # pylint: disable=consider-using-f-string
-    def to_string(self):
-        '''
-        to string method
-        '''
-        sep = ''
-        my_str = ''
-        for desc in self.configuration_parameter_set:
-            my_str = my_str + '{0}{1}\n'.format(sep, desc.to_string())
-            sep = ', '
+    def to_json(self):
+        return (json.dumps(self, cls=ConfigurationParameterDescriptorSetEncoder, indent=4))
 
-        return my_str
+
+class ConfigurationParameterDescriptorSetEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, ConfigurationParameterDescriptorSet):
+            return [
+                ConfigurationParameterDescriptorEncoder().default(configuration_parameter) for configuration_parameter in obj.configuration_parameter_set
+            ]
+        return super().default(obj)

--- a/tsp/configuration_set.py
+++ b/tsp/configuration_set.py
@@ -22,7 +22,8 @@
 
 """ConfigurationSet class file."""
 
-from tsp.configuration import Configuration
+import json
+from tsp.configuration import Configuration, ConfigurationEncoder
 
 
 # pylint: disable=too-few-public-methods
@@ -39,15 +40,17 @@ class ConfigurationSet:
         for obj in params:
             self.configuration_set.append(Configuration(obj))
 
+    def __repr__(self) -> str:
+        return 'ConfigurationSet({})'.format(', '.join(str(config) for config in self.configuration_set))
 
-    # pylint: disable=consider-using-f-string
-    def to_string(self):
-        '''
-        to string method
-        '''
-        my_str = ''
-        sep = ''
-        for desc in self.configuration_set:
-            my_str = my_str + '{0}{1}\n'.format(sep, desc.to_string())
-            sep = ', '
-        return my_str
+    def to_json(self):
+        return json.dumps(self, cls=ConfigurationSetEncoder, indent=4)
+
+
+class ConfigurationSetEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, ConfigurationSet):
+            return [
+                ConfigurationEncoder().default(configuration) for configuration in obj.configuration_set
+            ]
+        return super().default(obj)

--- a/tsp/configuration_source.py
+++ b/tsp/configuration_source.py
@@ -22,7 +22,8 @@
 
 """ConfigurationSource class file."""
 
-from tsp.configuration_parameter_descriptor_set import ConfigurationParameterDescriptorSet
+import json
+from tsp.configuration_parameter_descriptor_set import ConfigurationParameterDescriptorSet, ConfigurationParameterDescriptorSetEncoder
 
 NAME_KEY = "name"
 DESCTIPION_KEY = "description"
@@ -71,19 +72,27 @@ class ConfigurationSource:
             self.schema = params.get(SCHEMA_KEY)
             del params[SCHEMA_KEY]
 
-    # pylint: disable=consider-using-f-string
-    def to_string(self):
-        '''
-        to_string 
-        '''
-        my_str = "no parameter descriptor"
-        if self.parameter_descriptors is not None:
-            my_str = self.parameter_descriptors.to_string()
+    def __repr__(self):
+        return 'ConfigurationSource(id={}, name={}, description={}, parameter_descriptors={}, schema={})'.format(
+            self.id,
+            self.name,
+            self.description,
+            self.parameter_descriptors if self.parameter_descriptors is not None else 'None',
+            obj.schema if obj.schema is not None else 'None')
 
-        my_schema = "no schema"
-        if self.schema is not None:
-            my_schema = self.schema
+    def to_json(self):
+        return json.dumps(self, cls=ConfigurationSourceEncoder, indent=4)
 
-        return'Configuration Source[id={0}, name={1}, description: {2}, parameter_descriptor={3}, schema={4}]'.format(self.id,
-              self.name, self.description, my_str, my_schema)
+
+class ConfigurationSourceEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, ConfigurationSource):
+            return {
+                ID_KEY: obj.id,
+                NAME_KEY: obj.name,
+                DESCTIPION_KEY: obj.description,
+                PARAM_DESC_KEY: ConfigurationParameterDescriptorSetEncoder().default(obj.parameter_descriptors) if isinstance(obj.parameter_descriptors, ConfigurationParameterDescriptorSet) else "None",
+                SCHEMA_KEY: obj.schema if obj.schema is not None else 'None'
+            }
+        return super().default(obj)
 

--- a/tsp/configuration_source_set.py
+++ b/tsp/configuration_source_set.py
@@ -21,8 +21,8 @@
 # SOFTWARE.
 
 """ConfigurationSourceSet class file."""
-
-from tsp.configuration_source import ConfigurationSource
+import json
+from tsp.configuration_source import ConfigurationSource, ConfigurationSourceEncoder
 
 
 # pylint: disable=too-few-public-methods
@@ -39,16 +39,18 @@ class ConfigurationSourceSet:
         for obj in params:
             self.configuration_source_set.append(ConfigurationSource(obj))
 
-    # pylint: disable=consider-using-f-string
-    def to_string(self):
-        '''
-        to string method
-        '''
-        my_str = ''
-        sep = ''
-        for desc in self.configuration_source_set:
-            my_str = my_str + '{0}{1}\n'.format(sep, desc.to_string())
-            sep = ', '
-        return my_str
+    def __repr__(self) -> str:
+        return 'ConfigurationSourceSet({})'.format(', '.join(str(source) for source in self.configuration_source_set))
 
+    def to_json(self):
+        return json.dumps(self, cls=ConfigurationSourceSetEncoder, indent=4)
+
+
+class ConfigurationSourceSetEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, ConfigurationSourceSet):
+            return [
+                ConfigurationSourceEncoder().default(configuration_source) for configuration_source in obj.configuration_source_set
+            ]
+        return super().default(obj)
 

--- a/tsp/experiment.py
+++ b/tsp/experiment.py
@@ -102,16 +102,20 @@ class Experiment:
             self.name, self.UUID, self.start, self.end, self.number_of_events, self.traces, self.indexing_status
         )
 
+    def to_json(self):
+        return json.dumps(self, cls=ExperimentEncoder, indent=4)
+
+
 class ExperimentEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, Experiment):
             return {
-                'name': obj.name,
-                'UUID': obj.UUID,
-                'start': obj.start,
-                'end': obj.end,
-                'nbEvents': obj.number_of_events,
-                'indexing': obj.indexing_status.name,
-                'traces': TraceSetEncoder().default(obj.traces)
+                NAME_KEY: obj.name,
+                UUID_KEY: obj.UUID,
+                START_TIME_KEY: obj.start,
+                END_TIME_KEY: obj.end,
+                NB_EVENT_KEY: obj.number_of_events,
+                INDEXING_STATUS_KEY: obj.indexing_status.name,
+                TRACES_TIME_KEY: TraceSetEncoder().default(obj.traces)
             }
         return super().default(obj)

--- a/tsp/experiment_set.py
+++ b/tsp/experiment_set.py
@@ -39,6 +39,12 @@ class ExperimentSet:
         for obj in params:
             self.experiments.append(Experiment(obj))
 
+    def __repr__(self) -> str:
+        return 'ExperimentSet({})'.format(', '.join(str(trace) for trace in self.traces))
+
+    def to_json(self):
+        return json.dumps(self, cls=ExperimentSetEncoder, indent=4)
+
 class ExperimentSetEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, ExperimentSet):

--- a/tsp/health.py
+++ b/tsp/health.py
@@ -55,8 +55,6 @@ class Health:
         else:
             self.status = None
 
-    def to_string(self):
-        '''
-        to_string method
-        '''
-        return f"Health[status={self.status}]"
+
+    def __repr__(self):
+        return f"Health(status={self.status})"

--- a/tsp/identifier.py
+++ b/tsp/identifier.py
@@ -22,6 +22,8 @@
 
 """Identifier Service Class"""
 
+import json
+
 SERVER_VERSION = "version"
 BUILD_TIME = "buildTime"
 OS_NAME = "os"
@@ -113,8 +115,26 @@ class Identifier:
         else:
             self.tsp_version = None
 
-    def to_string(self):
-        '''
-        to_string method
-        '''
-        return f"Identifier[version={self.server_version}, buildTime={self.build_time}, os={self.os_name}, osArch={self.os_arch}, osVersion={self.os_version}, cpuCount={self.cpu_count}, maxMemory={self.max_memory}, productId={self.product_id}, launcherName={self.launcher_name}, tspVersion={self.tsp_version}]"
+    def __repr__(self):
+        return f'Identifier(version={self.server_version}, build_time={self.build_time}, os={self.os_name}, os_arch={self.os_arch}, os_version={self.os_version}, cpu_count={self.cpu_count}, max_memory={self.max_memory}, product_id={self.product_id}, launcher_name={self.launcher_name}, tsp_version={self.tsp_version})'
+
+    def to_json(self):
+        return json.dumps(self, cls=IdentifierEncoder, indent=4)
+
+
+class IdentifierEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, Identifier):
+            return {
+                SERVER_VERSION: obj.server_version,
+                BUILD_TIME: obj.build_time,
+                OS_NAME: obj.os_name,
+                OS_ARCH: obj.os_arch,
+                OS_VERSION: obj.os_version,
+                CPU_COUNT: obj.cpu_count,
+                MAX_MEMORY: obj.max_memory,
+                PRODUCT_ID: obj.product_id,
+                LAUNCHER_NAME: obj.launcher_name,
+                TSP_VERSION: obj.tsp_version
+            }
+        return super().default(obj)

--- a/tsp/output_descriptor.py
+++ b/tsp/output_descriptor.py
@@ -23,6 +23,7 @@
 """OutputDescriptor class file."""
 
 import json
+from tsp.configuration import Configuration, ConfigurationEncoder
 
 NA = "N/A"
 UNKOWN = "UNKNOWN"
@@ -117,20 +118,24 @@ class OutputDescriptor:
             self.compatible_providers = []
 
     def __repr__(self):
-        return 'OutputDescriptor(id={}, name={}, description={})'.format(self.id, self.name, self.description)
+        return 'OutputDescriptor(id={}, name={}, description={}, type={})'.format(self.id, self.name, self.description, obj.type)
+
+    def to_json(self):
+        return json.dumps(self, cls=OutputDescriptorEncoder, indent=4)
 
 class OutputDescriptorEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, OutputDescriptor):
             return {
-                'id': obj.id,
-                'name': obj.name,
-                'description': obj.description,
-                'type': obj.type,
-                'query_parameters': obj.query_parameters,
-                'start': obj.start,
-                'end': obj.end,
-                'final': obj.final,
-                'compatible_providers': obj.compatible_providers
+                ID_KEY: obj.id,
+                NAME_KEY: obj.name,
+                DESCRIPTION_KEY: obj.description,
+                TYPE_KEY: obj.type,
+                # Hide non-TSP fields
+                # QUERY_PARAMETERS_KEY: obj.query_parameters,
+                # START_TIME_KEY: obj.start,
+                # END_TIME_KEY: obj.end,
+                # IS_FINAL_KEY: obj.final,
+                # COMPATIBLE_PROVIDERS_KEY: obj.compatible_providers
             }
         return super().default(obj)

--- a/tsp/output_descriptor_set.py
+++ b/tsp/output_descriptor_set.py
@@ -22,7 +22,8 @@
 
 """OutputDescriptorSet class file."""
 
-from tsp.output_descriptor import OutputDescriptor
+import json
+from tsp.output_descriptor import OutputDescriptor, OutputDescriptorEncoder
 
 
 # pylint: disable=too-few-public-methods
@@ -40,4 +41,16 @@ class OutputDescriptorSet:
             self.descriptors.append(OutputDescriptor(obj))
 
     def __repr__(self):
-        return ', '.join([str(descriptor) for descriptor in self.descriptors])
+        return 'OutputDescriptorSet({})'.format(', '.join(str(descriptor) for descriptor in self.descriptors))
+
+    def to_json(self):
+        return json.dumps(self, cls=OutputDescriptorSetEncoder, indent=4)
+
+
+class OutputDescriptorSetEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, OutputDescriptorSet):
+            return [
+                OutputDescriptorEncoder().default(descriptor) for descriptor in obj.descriptors
+            ]
+        return super().default(obj)

--- a/tsp/trace.py
+++ b/tsp/trace.py
@@ -108,20 +108,25 @@ class Trace:
             self.indexing_status = 0
 
     def __repr__(self):
-        return 'Trace({}: UUID={}, start={}, end={}, nevent={}, path={}, indexing={})'.format(
-            self.name, self.UUID, self.start, self.end, self.number_of_events, self.path, self.indexing_status
+        return 'Trace({}: UUID={}, start={}, end={}, nevent={}, path={}, properties={} indexing={})'.format(
+            self.name, self.UUID, self.start, self.end, self.number_of_events, self.path, self.properties, self.indexing_status
         )
+    
+    def to_json(self):
+        return json.dumps(self, cls=TraceEncoder, indent=4)
+
 
 class TraceEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, Trace):
             return {
-                'name': obj.name,
-                'UUID': obj.UUID,
-                'start': obj.start,
-                'end': obj.end,
-                'nbEvents': obj.number_of_events,
-                'path': obj.path,
-                'indexing': obj.indexing_status.name
+                NAME_KEY: obj.name,
+                UUID_KEY: obj.UUID,
+                START_TIME_KEY: obj.start,
+                END_TIME_KEY: obj.end,
+                NB_EVENT_KEY: obj.number_of_events,
+                PATH_KEY: obj.path,
+                PROPERTIES_KEY: obj.properties,
+                INDEXING_STATUS_KEY: obj.indexing_status.name
             }
         return super().default(obj)

--- a/tsp/trace_set.py
+++ b/tsp/trace_set.py
@@ -25,7 +25,7 @@
 import json
 from tsp.trace import Trace, TraceEncoder
 
-# pylint: disable=too-few-public-methods
+
 class TraceSet:
     '''
     classdocs
@@ -41,6 +41,9 @@ class TraceSet:
 
     def __repr__(self) -> str:
         return 'TraceSet({})'.format(', '.join(str(trace) for trace in self.traces))
+
+    def to_json(self):
+        return json.dumps(self, cls=TraceSetEncoder, indent=4)
 
 class TraceSetEncoder(json.JSONEncoder):
     def default(self, obj):

--- a/tsp_cli_client
+++ b/tsp_cli_client
@@ -591,7 +591,9 @@ if __name__ == "__main__":
         if options.get_identifier:
             response = tsp_client.fetch_identifier()
             if response.status_code == 200:
-                print('  {0}'.format(response.model.to_string()))
+                print('Successfully listed identifier')
+                print('------------------------------')
+                print(response.model.to_json())
                 sys.exit(0)
             else:
                 sys.exit(1)

--- a/tsp_cli_client
+++ b/tsp_cli_client
@@ -41,30 +41,6 @@ from tsp.tsp_client import TspClient
 
 TRACE_MISSING = "Trace UUID is missing"
 
-# pylint: disable=consider-using-f-string
-
-
-def __print_uuid(elem):
-    return colored(elem.UUID, 'yellow')
-
-def __print_output(output):
-    print('  {0}: {1} {2} ({3})'.format(output.name,
-          output.description, output.type, output.id))
-
-
-# pylint: disable=fixme,line-too-long,undefined-loop-variable
-def __print_outputs(descriptors):
-    if not descriptors:
-        print('No output descriptors for trace {0} ({1}))'.format(
-            t.name, __print_uuid(t)))
-    for descriptor in output_descriptors.descriptors:
-        __print_output(descriptor)
-        # TODO remove when available
-        # if o.id == "org.eclipse.tracecompass.internal.analysis.profiling.callstack.provider.CallStackDataProvider"):
-        #    print('  {0}: {1} ({2})'.format("Function Duration Statistics", "Function Duration Statistics",
-        #          "org.eclipse.tracecompass.internal.analysis.profiling.core.callgraph.callgraphanalysis.statistics"))
-
-
 def __get_descriptor(uuid, output_id):
     resp = tsp_client.fetch_experiment_output(uuid, output_id)
     if resp.status_code == 200:
@@ -352,7 +328,12 @@ if __name__ == "__main__":
                 options.list_outputs)
             if response.status_code == 200:
                 output_descriptors = response.model
-                __print_outputs(output_descriptors.descriptors)
+                if not output_descriptors:
+                    print('No output descriptors for this trace')
+                else:
+                    print('Successfully listed outputs')
+                    print('---------------------------')
+                    print(output_descriptors.to_json())
                 sys.exit(0)
             else:
                 print("List outputs failed")
@@ -363,7 +344,9 @@ if __name__ == "__main__":
                 output_descriptor = __get_descriptor(
                     options.uuid, options.list_output)
                 if output_descriptor is not None:
-                    print(output_descriptor)
+                    print('Successfully listed output')
+                    print('--------------------------')
+                    print(output_descriptor.to_json())
             else:
                 print(TRACE_MISSING)
                 sys.exit(1)

--- a/tsp_cli_client
+++ b/tsp_cli_client
@@ -39,9 +39,6 @@ from termcolor import colored
 from tree_model import TreeModel
 from tsp.tsp_client import TspClient
 
-# api_token = 'your_token_goes_here'
-NS_PER_SEC = 1000000000
-
 TRACE_MISSING = "Trace UUID is missing"
 
 # pylint: disable=consider-using-f-string

--- a/tsp_cli_client
+++ b/tsp_cli_client
@@ -483,7 +483,9 @@ if __name__ == "__main__":
                 if not configuration_source_set or len(configuration_source_set.configuration_source_set) == 0:
                     print('No configuration sources available')
                 else:
-                    print('  {0}'.format(configuration_source_set.to_string()))
+                    print('Successfully listed configuration sources')
+                    print('-----------------------------------------')
+                    print(response.model.to_json())
                 sys.exit(0)
             else:
                 sys.exit(1)
@@ -491,9 +493,12 @@ if __name__ == "__main__":
         if options.list_configuration_source:
             response = tsp_client.fetch_configuration_source(options.list_configuration_source)
             if response.status_code == 200:
-                print('  {0}'.format(response.model.to_string()))
+                print('Successfully listed configuration source')
+                print('----------------------------------------')
+                print(response.model.to_json())
                 sys.exit(0)
             else:
+                print('No such configuration source')
                 sys.exit(1)
 
         if options.list_configurations:
@@ -503,7 +508,9 @@ if __name__ == "__main__":
                 if not configuration_set or len(configuration_set.configuration_set) == 0:
                     print('No configurations loaded')
                 else:
-                    print('  {0}'.format(configuration_set.to_string()))
+                    print('Successfully listed configurations')
+                    print('----------------------------------')
+                    print(response.model.to_json())
                 sys.exit(0)
             else:
                 sys.exit(1)
@@ -513,9 +520,12 @@ if __name__ == "__main__":
             if options.type_id is not None:
                 response = tsp_client.fetch_configuration(options.type_id, options.list_configuration)
                 if response.status_code == 200:
-                    print('  {0}'.format(response.model.to_string()))
+                    print('Successfully listed configuration')
+                    print('---------------------------------')
+                    print(response.model.to_json())
                     sys.exit(0)
                 else:
+                    print('No such configuration')
                     sys.exit(1)
             else:
                 print("No type id of configuration provided")
@@ -530,7 +540,9 @@ if __name__ == "__main__":
                     if (params is not None):
                         response = tsp_client.post_configuration(options.type_id, params)
                         if response.status_code == 200:
-                            print('  {0}'.format(response.model.to_string()))
+                            print('Successfully loaded configuration')
+                            print('---------------------------------')
+                            print(response.model.to_json())
                             sys.exit(0)
                         else:
                             sys.exit(1)
@@ -552,7 +564,9 @@ if __name__ == "__main__":
                         if (params is not None):
                             response = tsp_client.put_configuration(options.type_id, options.config_id, params)
                             if response.status_code == 200:
-                                print('  {0}'.format(response.model.to_string()))
+                                print('Successfully updated configuration')
+                                print('---------------------------------')
+                                print(response.model.to_json())
                                 sys.exit(0)
                             else:
                                 sys.exit(1)
@@ -573,7 +587,9 @@ if __name__ == "__main__":
             if options.type_id is not None:
                 response = tsp_client.delete_configuration(options.type_id, options.delete_configuration)
                 if response.status_code == 200:
-                    print('  {0}'.format(response.model.to_string()))
+                    print('Successfully deleted configuration')
+                    print('---------------------------------')
+                    print(response.model.to_json())
                     sys.exit(0)
                 else:
                     sys.exit(1)

--- a/tsp_cli_client
+++ b/tsp_cli_client
@@ -47,27 +47,6 @@ TRACE_MISSING = "Trace UUID is missing"
 def __print_uuid(elem):
     return colored(elem.UUID, 'yellow')
 
-
-def __print_experiment(elem):
-    print('Experiment:')
-    print('----------')
-    print('  {0}: ({1}) start={2} end={3} nbEvents={4} indexing={5}'.format(
-        elem.name, __print_uuid(elem), elem.start, elem.end,
-        elem.number_of_events, elem.indexing_status))
-    print('Trace(s):')
-    print('------')
-    for elem_trace in elem.traces.traces:
-        __print_trace(elem_trace)
-    
-    print('')
-
-
-def __print_trace(elem):
-    print('    {0}: {1} ({2}) start={3} end={4} nbEvents={5} properties={6} indexing={7}'.format(
-        elem.name, elem.path, __print_uuid(elem), elem.start, elem.end,
-        elem.number_of_events, elem.properties, elem.indexing_status))
-
-
 def __print_output(output):
     print('  {0}: {1} {2} ({3})'.format(output.name,
           output.description, output.type, output.id))
@@ -256,7 +235,9 @@ if __name__ == "__main__":
                 response = tsp_client.open_trace(options.name, options.trace)
                 if response.status_code == 200:
                     res = response.model
-                    __print_trace(res)
+                    print('Successfully opened trace')
+                    print('-------------------------')
+                    res.print()
                     sys.exit(0)
                 else:
                     sys.exit(1)
@@ -268,7 +249,9 @@ if __name__ == "__main__":
             response = tsp_client.fetch_trace(options.list_trace)
             if response.status_code == 200:
                 res = response.model
-                __print_trace(res)
+                print('Successfully listed trace')
+                print('-------------------------')
+                res.print()
                 sys.exit(0)
             else:
                 sys.exit(1)
@@ -278,8 +261,10 @@ if __name__ == "__main__":
             if response.status_code == 200:
                 if not response.model.traces:
                     print("No traces open on the server")
-                for t in response.model.traces:
-                    __print_trace(t)
+                else:
+                    print('Successfully listed traces')
+                    print('--------------------------')
+                    print(response.model.to_json())
                 sys.exit(0)
             else:
                 sys.exit(1)
@@ -287,7 +272,9 @@ if __name__ == "__main__":
         if options.delete_trace:
             response = tsp_client.delete_trace(options.delete_trace, False)
             if response.status_code == 200:
-                print("Successfully deleted trace")
+                print('Successfully deleted trace')
+                print('--------------------------')
+                print(response.model.to_json())
                 sys.exit(0)
             else:
                 sys.exit(1)
@@ -312,8 +299,9 @@ if __name__ == "__main__":
             response = tsp_client.open_experiment(
                 options.experiment, trace_uuids)
             if response.status_code == 200:
-                res = response.model
-                __print_experiment(res)
+                print('Successfully opened experiment')
+                print('------------------------------')
+                print(response.model.to_json())
                 sys.exit(0)
             else:
                 sys.exit(1)
@@ -321,8 +309,9 @@ if __name__ == "__main__":
         if options.list_experiment:
             response = tsp_client.fetch_experiment(options.list_experiment)
             if response.status_code == 200:
-                res = response.model
-                __print_experiment(res)
+                print('Successfully listed experiment')
+                print('------------------------------')
+                print(response.model.to_json())
                 sys.exit(0)
             else:
                 sys.exit(1)
@@ -332,8 +321,10 @@ if __name__ == "__main__":
             if response.status_code == 200:
                 if not response.model.experiments:
                     print("No experiments open on the server")
-                for exp in response.model.experiments:
-                    __print_experiment(exp)
+                else: 
+                    print('Successfully listed experiments')
+                    print('-------------------------------')
+                    print(response.model.to_json())
                 sys.exit(0)
             else:
                 sys.exit(1)
@@ -341,7 +332,9 @@ if __name__ == "__main__":
         if options.delete_experiment:
             response = tsp_client.delete_experiment(options.delete_experiment)
             if response.status_code == 200:
-                print("Successfully deleted experiment")
+                print('Successfully deleted experiment')
+                print('-------------------------------')
+                print(response.model.to_json())
                 if options.do_delete_traces:
                     for trace in response.model.traces.traces:
                         del_response = tsp_client.delete_trace(

--- a/tsp_cli_client
+++ b/tsp_cli_client
@@ -583,7 +583,7 @@ if __name__ == "__main__":
         if options.get_health:
             response = tsp_client.fetch_health()
             if response.status_code == 200:
-                print('  {0}'.format(response.model.to_string()))
+                print(response.model)
                 sys.exit(0)
             else:
                 sys.exit(1)


### PR DESCRIPTION
- Add JSON encoders, string and JSON representation for 
  - Identifier
  - Configuration related classes
  - Experiment and traces
  Use this to print identifier as JSON string. **This will increase the readability of the command-line results.**
- Replace to_string with string representation method for Health class
- Remove unused constant and comment in tsp_cli_client
- Add list-output example to README.md

To test the print-outs invoke the corresponding CLI commands.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>