### PR TITLE
Add custom analysis related APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ usage: tsp_cli_client [-h] [--ip IP] [--port PORT]
                       [--params PARAMS]
                       [--get-health]
                       [--get-identifier]
+                      [--list-output-configuration-sources OUTPUT_ID]
+                      [--list-output-configuration-source TYPE_ID]
+                      [--create-output OUTPUT_ID]
+                      [--delete-output DERIVED_OUTPUT_ID]
+                      [--output-id OUTPUT_ID]
+                      [--json-file JSON_FILE]
 
 CLI client to send Trace Server Protocol commands to a Trace Server.
 
@@ -160,6 +166,18 @@ optional arguments:
   --params PARAMS       comma separated key value pairs (key1=val1,key2=val2)
   --get-health          Get the health status of the server
   --get-identifier      Identify important information regarding the server and the system
+  --list-output-configuration-sources OUTPUT_ID
+                        Get available configuration sources for a given experiment and output
+  --list-output-configuration-source TYPE_ID
+                        Get configuration source for a given experiment, output and type
+  --create-output OUTPUT_ID
+                        Create derived output provided by --param or --json-file
+  --delete-output DERIVED_OUTPUT_ID
+                        Delete derived output
+  --output-id OUTPUT_ID
+                        The output ID
+  --json-file JSON_FILE
+                        JSON file with parameter
 ```
 
 Examples:
@@ -190,6 +208,10 @@ Examples:
   ./tsp_cli_client --load-configuration --type-id TYPE_ID --params key1:value1
   ./tsp_cli_client --update-configuration --type-id TYPE_ID --config-id CONFIG_ID --params key1=value1,key2=value2
   ./tsp_cli_client --delete-configuration CONFIGURATION_ID --type-id TYPE_ID
+  ./tsp_cli_client --list-output-configuration-sources OUTPUT_ID --uuid UUID
+  ./tsp_cli_client --list-output-configuration-source TYPE_ID --output-id OUTPUT_ID --uuid UUID
+  ./tsp_cli_client --create-output OUTPUT_ID --uuid UUID --json-file absolute-path-to-json-file
+  ./tsp_cli_client --delete-output DERIVED_OUTPUT_ID --output-id  OUTPUT_ID --uuid UUID
   ./tsp_cli_client --get-health
   ./tsp_cli_client --get-identifier
 ```

--- a/README.md
+++ b/README.md
@@ -205,7 +205,9 @@ Examples:
   ./tsp_cli_client --list-configuration-source TYPE_ID
   ./tsp_cli_client --list-configurations TYPE_ID
   ./tsp_cli_client --list-configuration CONFIG_ID --type-id TYPE_ID
+  ./tsp_cli_client --load-configuration --type-id TYPE_ID --json-file absolute-path-to-json-file
   ./tsp_cli_client --load-configuration --type-id TYPE_ID --params key1:value1
+  ./tsp_cli_client --update-configuration --type-id TYPE_ID --config-id CONFIG_ID --json-file absolute-path-to-json-file
   ./tsp_cli_client --update-configuration --type-id TYPE_ID --config-id CONFIG_ID --params key1=value1,key2=value2
   ./tsp_cli_client --delete-configuration CONFIGURATION_ID --type-id TYPE_ID
   ./tsp_cli_client --list-output-configuration-sources OUTPUT_ID --uuid UUID

--- a/tsp/tsp_client.py
+++ b/tsp/tsp_client.py
@@ -49,6 +49,7 @@ headers_form = {'content-type': 'application/x-www-form-urlencoded',
 GET_TREE_FAILED = "failed to get tree: {0}"
 GET_STATES_FAILED = "failed to get states: {0}"
 GET_ARROWS_FAILED = "failed to get arrows: {0}"
+GET_CONFIG_SOURCE_TYPES = "failed to get config source type(s): {} {}"
 
 
 # pylint: disable=consider-using-f-string,missing-timeout
@@ -472,6 +473,86 @@ class TspClient:
                                      response.status_code, response.text)
         else:  # pragma: no cover
             print("failed to get xy: {0}".format(response.status_code))
+            return TspClientResponse(None, response.status_code, response.text)
+
+
+    def fetch_output_configuration_sources(self, exp_uuid, output_id):
+        '''
+        Fetch all configuration source types for a given experiment and output
+        :param exp_uuid Experiment UUID
+        :param output_id Output ID
+        :returns :class:`TspClientResponse <ConfigurationSourceSet>` object
+        :rtype: TspClientResponse
+        '''
+        api_url = '{0}experiments/{1}/outputs/{2}/configTypes'.format(
+            self.base_url, exp_uuid, output_id)
+        response = requests.get(api_url, headers=headers)
+        if response.status_code == 200:
+            return TspClientResponse(ConfigurationSourceSet(json.loads(response.content.decode('utf-8'))),
+                                     response.status_code, response.text)
+        else:  # pragma: no cover
+            print(GET_CONFIG_SOURCE_TYPES.format(response.status_code, response.text))
+            return TspClientResponse(None, response.status_code, response.text)
+
+    def fetch_output_configuration_source(self, exp_uuid, output_id, type_id):
+        '''
+        Fetch a single configuration source type for a given experiment, output and type
+        :param exp_uuid Experiment UUID
+        :param output_id Output ID
+        :param type_id the ID of the configuration source type
+        :returns :class:`TspClientResponse <ConfigurationSource>` object
+        :rtype: TspClientResponse
+        '''
+        api_url = '{0}experiments/{1}/outputs/{2}/configTypes/{3}'.format(
+            self.base_url, exp_uuid, output_id, type_id)
+        response = requests.get(api_url, headers=headers)
+        if response.status_code == 200:
+            return TspClientResponse(ConfigurationSource(json.loads(response.content.decode('utf-8'))),
+                                     response.status_code, response.text)
+        else:  # pragma: no cover
+            print(GET_CONFIG_SOURCE_TYPES.format(response.status_code, response.text))
+            return TspClientResponse(None, response.status_code, response.text)
+
+    def create_derived_output(self, exp_uuid, output_id, params):
+        '''
+        Create a derived output for a given experiment, output and parameters
+        :param exp_uuid Experiment UUID
+        :param output_id Output ID
+        :param params output query params (JSON)
+        :returns :class:`TspClientResponse <OutputDescriptor>` object
+        :rtype: TspClientResponse
+        '''
+        api_url = '{0}experiments/{1}/outputs/{2}'.format(
+            self.base_url, exp_uuid, output_id)
+
+        response = requests.post(api_url, json=params, headers=headers)
+
+        if response.status_code == 200:
+            return TspClientResponse(OutputDescriptor(json.loads(response.content.decode('utf-8'))),
+                                     response.status_code, response.text)
+        else:  # pragma: no cover
+            print("failed to create derived output: {} {}".format(response.status_code, response.text))
+            return TspClientResponse(None, response.status_code, response.text)
+
+    def delete_derived_output(self, exp_uuid, output_id, derived_output_id):
+        '''
+        Create a derived output for a given experiment, output and parameters
+        :param exp_uuid Experiment UUID
+        :param output_id Output ID
+        :param derived_output_id the ID of the derived output
+        :returns :class:`TspClientResponse <OutputDescriptor>` object
+        :rtype: TspClientResponse
+        '''
+        api_url = '{0}experiments/{1}/outputs/{2}/{3}'.format(
+            self.base_url, exp_uuid, output_id, derived_output_id)
+
+        response = requests.delete(api_url, headers=headers_form)
+
+        if response.status_code == 200:
+            return TspClientResponse(OutputDescriptor(json.loads(response.content.decode('utf-8'))),
+                                     response.status_code, response.text)
+        else:  # pragma: no cover
+            print("delete derived output failed: {} {}".format(response.status_code, response.text))
             return TspClientResponse(None, response.status_code, response.text)
 
     def fetch_configuration_sources(self):

--- a/tsp_cli_client
+++ b/tsp_cli_client
@@ -27,6 +27,7 @@
 """Manual CLI script file."""
 
 import argparse
+import json
 import sys
 
 from os.path import os
@@ -193,6 +194,14 @@ if __name__ == "__main__":
     parser.add_argument("--params", dest="params", help="semicolon separated key value pairs (key1=val1;key2=val2)")
     parser.add_argument("--get-health", dest="get_health", action='store_true', help="Get the health status of the server")
     parser.add_argument("--get-identifier", dest="get_identifier", action='store_true', help="Get important information regarding the trace server and the system")
+    parser.add_argument("--list-output-configuration-sources", dest="list_output_configuration_sources",
+                        help="Get available configuration sources for a given experiment and output", metavar="OUTPUT_ID")
+    parser.add_argument("--list-output-configuration-source", dest="list_output_configuration_source",
+                        help="Get configuration source for a given experiment, output and type", metavar="TYPE_ID")
+    parser.add_argument("--create-output", dest="create_output", help="Create derived output provided by --param or --json-file", metavar="OUTPUT_ID")
+    parser.add_argument("--delete-output", dest="delete_output", help="Delete derived output", metavar="DERIVED_OUTPUT_ID")
+    parser.add_argument("--output-id", dest="output_id", help="The output ID")
+    parser.add_argument("--json-file", dest="json_file", help="JSON file with parameter")
 
     argcomplete.autocomplete(parser)
     options = parser.parse_args()
@@ -509,7 +518,6 @@ if __name__ == "__main__":
                 sys.exit(1)
 
 
-
         if options.load_configuration:
             if options.type_id is not None:
                 if options.params is not None:
@@ -572,6 +580,94 @@ if __name__ == "__main__":
                     sys.exit(1)
             else:
                 print("No source typeId provided to delete this configuration")
+
+        if options.list_output_configuration_sources:
+            if not options.uuid:
+                print(TRACE_MISSING)
+                sys.exit(1)
+
+            response = tsp_client.fetch_output_configuration_sources(options.uuid, options.list_output_configuration_sources)
+            if response.status_code == 200:
+                configuration_source_set = response.model
+                if not configuration_source_set or len(configuration_source_set.configuration_source_set) == 0:
+                    print('No configuration sources available')
+                else:
+                    print('Successfully listed configuration sources')
+                    print('-----------------------------------------')
+                    print(configuration_source_set.to_json())
+                sys.exit(0)
+            else:
+                sys.exit(1)
+
+        if options.list_output_configuration_source:
+            if not options.uuid:
+                print(TRACE_MISSING)
+                sys.exit(1)
+
+            if not options.output_id:
+                print("No output ID provided")
+                sys.exit(1)
+
+            response = tsp_client.fetch_output_configuration_source(options.uuid, options.output_id, options.list_output_configuration_source)
+            if response.status_code == 200:
+                configuration_source = response.model
+                if not configuration_source:
+                    print('No configuration sources available')
+                else:
+                    print('Successfully listed configuration sources')
+                    print('-----------------------------------------')
+                    print(configuration_source.to_json())
+                sys.exit(0)
+            else:
+                sys.exit(1)
+
+        if options.create_output:
+            if not options.uuid:
+                print(TRACE_MISSING)
+                sys.exit(1)
+
+            if not options.params and not options.json_file:
+                print("No parameters provided with --param or --json-file")
+                sys.exit(1)
+            
+            params = {}
+            if options.params is not None:
+                params = __parse_params(options.params)
+
+            if options.json_file is not None:
+                with open(options.json_file, 'r') as file:
+                    params = json.loads(file.read())
+
+            if (params is not None):
+                response = tsp_client.create_derived_output(options.uuid, options.create_output, params)
+                if response.status_code == 200:
+                    print('Successfully created derived output')
+                    print('-----------------------------------')
+                    print(response.model.to_json())
+                    sys.exit(0)
+                else:
+                    sys.exit(1)
+            else:
+                print("Invalid params provided")
+                sys.exit(1)
+
+        if options.delete_output:
+            if not options.uuid:
+                print(TRACE_MISSING)
+                sys.exit(1)
+
+            if not options.output_id:
+                print("No parent output ID provided")
+                sys.exit(1)
+            
+            response = tsp_client.delete_derived_output(options.uuid, options.output_id, options.delete_output)
+            if response.status_code == 200:
+                print('Successfully deleted derived output')
+                print('-----------------------------------')
+                print(response.model.to_json())
+                sys.exit(0)
+            else:
+                sys.exit(1)
 
         if options.get_health:
             response = tsp_client.fetch_health()

--- a/tsp_cli_client
+++ b/tsp_cli_client
@@ -108,6 +108,24 @@ def __parse_params (parameters_string):
 
     return _params
 
+def __get_parameters(options):
+    if not options.params and not options.json_file:
+        print("No parameters provided with --params or --json-file")
+        sys.exit(1)
+
+    _params = {}
+    if options.params is not None:
+        _params = __parse_params(options.params)
+
+    if options.json_file is not None:
+        with open(options.json_file, 'r') as file:
+            _params = json.loads(file.read())
+
+        if not _params:
+            print("Invalid params provided")
+            sys.exit(1)
+    return _params
+
 
 DESCRIPTION = """CLI client to send Trace Server Protocol commands to a Trace Server."""
 
@@ -523,21 +541,7 @@ if __name__ == "__main__":
                 print("No type-id for loading of configuration provided")
                 sys.exit(1)
 
-            if not options.params and not options.json_file:
-                print("No parameters provided with --params or --json-file")
-                sys.exit(1)
-
-            params = {}
-            if options.params is not None:
-                params = __parse_params(options.params)
-
-            if options.json_file is not None:
-                with open(options.json_file, 'r') as file:
-                    params = json.loads(file.read())
-
-            if not params:
-                print("Invalid params provided")
-                sys.exit(1)
+            params = __get_parameters(options)
 
             response = tsp_client.post_configuration(options.type_id, params)
             if response.status_code == 200:
@@ -557,21 +561,7 @@ if __name__ == "__main__":
                 print("No config-id of configuration provided")
                 sys.exit(1)
 
-            if not options.params and not options.json_file:
-                print("No parameters provided with --params or --json-file")
-                sys.exit(1)
-
-            params = {}
-            if options.params is not None:
-                params = __parse_params(options.params)
-
-            if options.json_file is not None:
-                with open(options.json_file, 'r') as file:
-                    params = json.loads(file.read())
-
-            if not params:
-                print("Invalid params provided")
-                sys.exit(1)
+            params = __get_parameters(options)
 
             response = tsp_client.put_configuration(options.type_id, options.config_id, params)
             if response.status_code == 200:
@@ -640,29 +630,15 @@ if __name__ == "__main__":
                 print(TRACE_MISSING)
                 sys.exit(1)
 
-            if not options.params and not options.json_file:
-                print("No parameters provided with --params or --json-file")
-                sys.exit(1)
-            
-            params = {}
-            if options.params is not None:
-                params = __parse_params(options.params)
+            params = __get_parameters(options)
 
-            if options.json_file is not None:
-                with open(options.json_file, 'r') as file:
-                    params = json.loads(file.read())
-
-            if (params is not None):
-                response = tsp_client.create_derived_output(options.uuid, options.create_output, params)
-                if response.status_code == 200:
-                    print('Successfully created derived output')
-                    print('-----------------------------------')
-                    print(response.model.to_json())
-                    sys.exit(0)
-                else:
-                    sys.exit(1)
+            response = tsp_client.create_derived_output(options.uuid, options.create_output, params)
+            if response.status_code == 200:
+                print('Successfully created derived output')
+                print('-----------------------------------')
+                print(response.model.to_json())
+                sys.exit(0)
             else:
-                print("Invalid params provided")
                 sys.exit(1)
 
         if options.delete_output:

--- a/tsp_cli_client
+++ b/tsp_cli_client
@@ -41,6 +41,7 @@ from tsp.tsp_client import TspClient
 
 TRACE_MISSING = "Trace UUID is missing"
 
+
 def __get_descriptor(uuid, output_id):
     resp = tsp_client.fetch_experiment_output(uuid, output_id)
     if resp.status_code == 200:

--- a/tsp_cli_client
+++ b/tsp_cli_client
@@ -184,9 +184,9 @@ if __name__ == "__main__":
     parser.add_argument("--list-configuration", dest="list_configuration",
                         help="Get a configuration loaded for given type and config id", metavar="CONFIG_ID")
     parser.add_argument("--load-configuration", dest="load_configuration",
-                        action='store_true', help="Load an configuration using paramemeters provided by --params")
+                        action='store_true', help="Load an configuration using paramemeters provided by --params or --json-file")
     parser.add_argument("--update-configuration", dest="update_configuration",
-                        action='store_true', help="Update an configuration using paramemeters provided by --params")
+                        action='store_true', help="Update an configuration using paramemeters provided by --params or --json-file")
     parser.add_argument("--delete-configuration", dest="delete_configuration",
                         help="Delete a configuration", metavar="CONFIGURATION_ID")
     parser.add_argument("--type-id", dest="type_id", help="id of configuration source type")
@@ -519,53 +519,67 @@ if __name__ == "__main__":
 
 
         if options.load_configuration:
-            if options.type_id is not None:
-                if options.params is not None:
-                    params = __parse_params(options.params)
-                    if (params is not None):
-                        response = tsp_client.post_configuration(options.type_id, params)
-                        if response.status_code == 200:
-                            print('Successfully loaded configuration')
-                            print('---------------------------------')
-                            print(response.model.to_json())
-                            sys.exit(0)
-                        else:
-                            sys.exit(1)
-                    else:
-                        print("Invalid params provided")
-                        sys.exit(1)
-                else:
-                    print("No params provided")
-                    sys.exit(1)
+            if not options.type_id:
+                print("No type-id for loading of configuration provided")
+                sys.exit(1)
+
+            if not options.params and not options.json_file:
+                print("No parameters provided with --params or --json-file")
+                sys.exit(1)
+
+            params = {}
+            if options.params is not None:
+                params = __parse_params(options.params)
+
+            if options.json_file is not None:
+                with open(options.json_file, 'r') as file:
+                    params = json.loads(file.read())
+
+            if not params:
+                print("Invalid params provided")
+                sys.exit(1)
+
+            response = tsp_client.post_configuration(options.type_id, params)
+            if response.status_code == 200:
+                print('Successfully loaded configuration')
+                print('---------------------------------')
+                print(response.model.to_json())
+                sys.exit(0)
             else:
-                print("No type id of configuration provided")
                 sys.exit(1)
 
         if options.update_configuration:
-            if options.type_id is not None:
-                if (options.config_id is not None):
-                    if options.params is not None:
-                        params = __parse_params(options.params);
-                        if (params is not None):
-                            response = tsp_client.put_configuration(options.type_id, options.config_id, params)
-                            if response.status_code == 200:
-                                print('Successfully updated configuration')
-                                print('---------------------------------')
-                                print(response.model.to_json())
-                                sys.exit(0)
-                            else:
-                                sys.exit(1)
-                        else:
-                            print("Invalid params provided")
-                            sys.exit(1)
-                    else:
-                        print("No params provided")
-                        sys.exit(1)
-                else:
-                    print("No config id if configuration provided")
-                    sys.exit(1)
+            if not options.type_id:
+                print("No type-id for updating of configuration provided")
+                sys.exit(1)
+
+            if not options.config_id:
+                print("No config-id of configuration provided")
+                sys.exit(1)
+
+            if not options.params and not options.json_file:
+                print("No parameters provided with --params or --json-file")
+                sys.exit(1)
+
+            params = {}
+            if options.params is not None:
+                params = __parse_params(options.params)
+
+            if options.json_file is not None:
+                with open(options.json_file, 'r') as file:
+                    params = json.loads(file.read())
+
+            if not params:
+                print("Invalid params provided")
+                sys.exit(1)
+
+            response = tsp_client.put_configuration(options.type_id, options.config_id, params)
+            if response.status_code == 200:
+                print('Successfully updated configuration')
+                print('---------------------------------')
+                print(response.model.to_json())
+                sys.exit(0)
             else:
-                print("No type id of configuration provided")
                 sys.exit(1)
 
         if options.delete_configuration:
@@ -627,7 +641,7 @@ if __name__ == "__main__":
                 sys.exit(1)
 
             if not options.params and not options.json_file:
-                print("No parameters provided with --param or --json-file")
+                print("No parameters provided with --params or --json-file")
                 sys.exit(1)
             
             params = {}


### PR DESCRIPTION
**Changes (multiple commits)**
- Support parentId and creation configuration in output descriptors
- Add APIs to support configurable output (data provider)
  - Add configuration service per output (data provider)
  This addition enables clients to create derived data providers from
  an existing data provider.
  - Add unit tests
  - Add cli to invoke new endpoints
- Support JSON file for load-configuration and update-configuration
  This allows users to use a file with JSON parameters.
- Extract method for parsing/validating options.params/option.json_file

**To Test**

With Trace Compass Trace Server of today, the new CLI commands below can be used to configure InAndOut analysis, with LTTng Kernel traces or UST traces with function entry or exit.

```
  ./tsp_cli_client --list-output-configuration-sources OUTPUT_ID --uuid UUID
  ./tsp_cli_client --list-output-configuration-source TYPE_ID --output-id OUTPUT_ID --uuid UUID
  ./tsp_cli_client --create-output OUTPUT_ID --uuid UUID --json-file absolute-path-to-json-file
  ./tsp_cli_client --delete-output DERIVED_OUTPUT_ID --output-id  OUTPUT_ID --uuid UUID

where:
OUTPUT_ID = org.eclipse.tracecompass.incubator.inandout.core.analysis.inAndOutdataProviderFactory
TYPE_ID = org.eclipse.tracecompass.incubator.internal.inandout.core.config
UUID = UUID of experiment
```

Content of JSON file:
```
{
   "name": "my other InAndOut",
   "description" : "my description",
   "sourceTypeId": "org.eclipse.tracecompass.incubator.internal.inandout.core.config",
   "parameters": {
       "specifiers" : [
           {
           "label":"latency",
           "inRegex":"(\\S*)_entry",
           "outRegex":"(\\S*)_exit",
           "contextInRegex":"(\\S*)_entry",
           "contextOutRegex":"(\\S*)_exit",
           "classifier":"CPU"
           }
       ]
   }
}

```

**Note:** This PR includes changes of #86 which needs to merged before.


Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>