### PR TITLE
Add optional OutputCapabilities to the output descriptor (DataProvider)

### DIFF
--- a/test_tsp.py
+++ b/test_tsp.py
@@ -36,6 +36,7 @@ from tsp.virtual_table_tag import VirtualTableTag
 from tsp.configuration_source import ConfigurationSource
 from tsp.configuration_source_set import ConfigurationSourceSet
 from tsp.output_descriptor import OutputDescriptor
+from tsp.output_capabilities import OutputCapabilities
 
 STATISTICS_DP_ID = (
     "org.eclipse.tracecompass.analysis.timing.core.segmentstore.SegmentStoreStatisticsDataProvider:"
@@ -756,6 +757,10 @@ class TestTspClient:
         assert response.model
         assert isinstance(response.model, OutputDescriptor)
         assert response.model.parent_id == INANDOUT_DP_ID
+
+        assert isinstance(response.model.capabilities, OutputCapabilities)
+        assert response.model.capabilities.can_create == False
+        assert response.model.capabilities.can_delete == True
 
         derived_id = response.model.id
 

--- a/tsp/output_capabilities.py
+++ b/tsp/output_capabilities.py
@@ -1,0 +1,70 @@
+# The MIT License (MIT)
+#
+# Copyright (C) 2025 - Ericsson
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""OutputDescriptor class file."""
+
+import json
+
+CAN_CREATE_KEY = "canCreate"
+CAN_DELETE_KEY = "canDelete"
+
+# pylint: disable=too-few-public-methods,too-many-instance-attributes
+class OutputCapabilities:
+    '''
+    classdocs
+    '''
+
+    # pylint: disable=too-many-branches
+    def __init__(self, params):
+        '''
+        Constructor
+        '''
+
+        # Capability canCreate
+        if CAN_CREATE_KEY in params:
+            # pylint: disable=invalid-name
+            self.can_create = params.get(CAN_CREATE_KEY)
+            del params[CAN_CREATE_KEY]
+        else:  # pragma: no cover
+            self.can_create = None
+
+        if CAN_DELETE_KEY in params:
+            # pylint: disable=invalid-name
+            self.can_delete = params.get(CAN_DELETE_KEY)
+            del params[CAN_DELETE_KEY]
+        else:  # pragma: no cover
+            self.can_delete = None
+
+    def __repr__(self):
+        return 'OutputCapabilities(canCreate={}, canDelete={})'.format(self.can_create, self.can_delete)
+
+    def to_json(self):
+        return json.dumps(self, cls=OutputCapabilities, indent=4)
+
+class OutputCapabilitiesEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, OutputCapabilities):
+            return {
+                'canCreate': obj.can_create,
+                'canDelete': obj.can_delete
+            }
+        return super().default(obj)

--- a/tsp/output_descriptor.py
+++ b/tsp/output_descriptor.py
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 #
-# Copyright (C) 2020 - Ericsson
+# Copyright (C) 2020 - 2025 - Ericsson
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,6 +24,7 @@
 
 import json
 from tsp.configuration import Configuration, ConfigurationEncoder
+from tsp.output_capabilities import OutputCapabilities, OutputCapabilitiesEncoder
 
 NA = "N/A"
 UNKOWN = "UNKNOWN"
@@ -38,6 +39,7 @@ END_TIME_KEY = "end"
 IS_FINAL_KEY = "final"
 COMPATIBLE_PROVIDERS_KEY = "compatibleProviders"
 CONFIGURATION_KEY = "configuration"
+CAPABILITES_KEY = "capabilities"
 
 
 # pylint: disable=too-few-public-methods,too-many-instance-attributes
@@ -133,6 +135,13 @@ class OutputDescriptor:
             del params[CONFIGURATION_KEY]
         else:
             self.configuration = []
+        
+        # Capabilites of this data provider.
+        if CAPABILITES_KEY in params:
+            self.capabilities = OutputCapabilities(params.get(CAPABILITES_KEY))
+            del params[CAPABILITES_KEY]
+        else:
+            self.capabilities = None
 
 
     def __repr__(self):
@@ -163,5 +172,9 @@ class OutputDescriptorEncoder(json.JSONEncoder):
             # optional configuration
             if isinstance(obj.configuration, Configuration):
                 result[CONFIGURATION_KEY] = ConfigurationEncoder().default(obj.configuration)
+
+            # optional capabilities
+            if isinstance(obj.capabilities, OutputCapabilities):
+                result[CAPABILITES_KEY] = OutputCapabilitiesEncoder().default(obj.capabilities)
             return result
         return super().default(obj)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/tsp-python-client/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

OutputCapabilities indicate capabilities of am output, such as "canCreate" and "canDelete". "canCreate" indicates that a given output can create a derived outputs. "canDelete" indicates that a given output can be deleted.

See ADR: https://github.com/eclipse-cdt-cloud/theia-trace-extension/pull/1158

### How to test

Run unit tests or query output descriptors of an experiment using Trace Compass server. The `InAndOutConfigurator` will have capabilities ser

### Follow-ups

N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>